### PR TITLE
Fix view(), add max events to open(), offsets for open/load, relax numpy<2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -231,3 +231,4 @@ tests/quickview.py
 
 # Large local development fixtures (multi-GB; keep local, never commit)
 data/development/
+data/test/sunset2.hdf5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "eventcv-core"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "hdf5-metno",
  "ndarray",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "eventcv-py"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bytemuck",
  "eventcv-core",

--- a/crates/eventcv-core/Cargo.toml
+++ b/crates/eventcv-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eventcv-core"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 description = "Rust core of EventCV — OpenCV for event-based vision."
 license = "Apache-2.0"

--- a/crates/eventcv-core/src/io.rs
+++ b/crates/eventcv-core/src/io.rs
@@ -20,7 +20,8 @@ pub use h5::{
 pub use npz::{read_npz, read_npz_frame, write_npz_frame, write_npz_stream};
 pub use prophesee::read_dat;
 pub use text::{
-    open_text_slice, read_text, write_text_stream, ColumnOrder, TextOptions, TextReader, TimeUnit,
+    load_rows, open_text_slice, read_text, write_text_stream, ColumnOrder, RawRow, TextOptions,
+    TextReader, TimeUnit,
 };
 
 use crate::representation::EventFrame;
@@ -82,6 +83,9 @@ pub struct LoadOptions {
     pub topic: Option<String>,
     /// Cap on the number of events to read.
     pub max_events: Option<usize>,
+    /// Absolute timestamp (µs, the file's own time base): events before it are skipped.
+    /// `max_events` then caps the events *after* the offset. `None`/`<= 0` reads from the start.
+    pub offset: Option<i64>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -126,14 +130,42 @@ fn detect_format(path: &Path) -> Result<Format, IoError> {
 /// `.aedat` (AEDAT 2.0), and `.dat` (Prophesee CD).
 pub fn load(path: impl AsRef<Path>, options: LoadOptions) -> Result<EventStream, IoError> {
     let path = path.as_ref();
+    let Some(cutoff) = options.offset.filter(|&offset| offset > 0) else {
+        return load_format(path, &options);
+    };
+    // The offset is an absolute timestamp, so the whole recording must be read before
+    // skipping; the cap then applies to the events at/after the offset.
+    let mut read_options = options.clone();
+    read_options.max_events = None;
+    load_format(path, &read_options).map(|stream| skip_before(stream, cutoff, options.max_events))
+}
+
+/// Drops events before the absolute timestamp `cutoff` (µs), then keeps at most `max` of the rest.
+fn skip_before(stream: EventStream, cutoff: i64, max: Option<usize>) -> EventStream {
+    let (ts, (xs, ys, ps)) = (stream.ts(), (stream.xs(), stream.ys(), stream.ps()));
+    if ts.is_empty() {
+        return stream;
+    }
+    let (width, height) = stream.sensor_size();
+    let mut builder = EventStreamBuilder::new(width, height, stream.timestamp_scale_ms());
+    for index in (0..ts.len()).filter(|&index| ts[index] >= cutoff) {
+        builder.push(xs[index], ys[index], ts[index], ps[index]);
+        if max.is_some_and(|max| builder.len() >= max) {
+            break;
+        }
+    }
+    builder.build()
+}
+
+fn load_format(path: &Path, options: &LoadOptions) -> Result<EventStream, IoError> {
     match detect_format(path)? {
         Format::Npz => npz::read_npz(path, options.sensor_size),
-        Format::Text => text::load_text(path, &options),
-        Format::Rosbag => bag::read_bag(path, &options),
+        Format::Text => text::load_text(path, options),
+        Format::Rosbag => bag::read_bag(path, options),
         Format::Hdf5 => {
             #[cfg(feature = "hdf5")]
             {
-                h5::read_hdf5(path, &options)
+                h5::read_hdf5(path, options)
             }
             #[cfg(not(feature = "hdf5"))]
             {
@@ -142,12 +174,12 @@ pub fn load(path: impl AsRef<Path>, options: LoadOptions) -> Result<EventStream,
                 ))
             }
         }
-        Format::Aedat => aedat::read_aedat(path, &options),
+        Format::Aedat => aedat::read_aedat(path, options),
         Format::Aedat4 => Err(IoError::Unsupported(
             "AEDAT4 (.aedat4, iniVation DV FlatBuffer/LZ4) reading is not implemented yet"
                 .to_owned(),
         )),
-        Format::PropheseeDat => prophesee::read_dat(path, &options),
+        Format::PropheseeDat => prophesee::read_dat(path, options),
         Format::PropheseeRaw => Err(IoError::Unsupported(
             "Prophesee .raw (EVT2/EVT3) reading is not implemented yet".to_owned(),
         )),

--- a/crates/eventcv-core/src/io/text.rs
+++ b/crates/eventcv-core/src/io/text.rs
@@ -243,11 +243,12 @@ pub fn read_text(path: impl AsRef<Path>, options: TextOptions) -> Result<EventSt
 
 /// One parsed row before unit conversion / bounds filtering. The inference path needs
 /// the *raw* timestamp (to detect the unit), so it can't go through [`TextReader`].
-struct RawRow {
-    x: u16,
-    y: u16,
-    t: f64,
-    p: bool,
+/// Also the input to [`load_rows`], the in-memory (`from_numpy`) loader.
+pub struct RawRow {
+    pub x: u16,
+    pub y: u16,
+    pub t: f64,
+    pub p: bool,
 }
 
 /// Loads a text file, inferring whichever of `sensor_size` (from the coordinate range)
@@ -266,16 +267,23 @@ pub fn load_text(path: impl AsRef<Path>, options: &LoadOptions) -> Result<EventS
     }
 
     let rows = read_raw_rows(path.as_ref(), options.order)?;
+    load_rows(&rows, options)
+}
+
+/// Builds an [`EventStream`] from already-parsed rows, inferring whichever of
+/// `sensor_size`/`time_unit` the caller left unset (the in-memory twin of
+/// [`load_text`], shared with `eventcv.from_numpy`).
+pub fn load_rows(rows: &[RawRow], options: &LoadOptions) -> Result<EventStream, IoError> {
     let (width, height) = options
         .sensor_size
-        .unwrap_or_else(|| infer_sensor_size(&rows));
-    let time_unit = options.time_unit.unwrap_or_else(|| infer_time_unit(&rows));
+        .unwrap_or_else(|| infer_sensor_size(rows));
+    let time_unit = options.time_unit.unwrap_or_else(|| infer_time_unit(rows));
     if width == 0 || height == 0 {
         return Err(IoError::InvalidSensorSize);
     }
 
     let mut builder = EventStreamBuilder::new(width, height, 0.001);
-    for row in &rows {
+    for row in rows {
         builder.push(row.x, row.y, time_unit.to_microseconds(row.t), row.p);
         if options.max_events.is_some_and(|max| builder.len() >= max) {
             break;

--- a/crates/eventcv-py/Cargo.toml
+++ b/crates/eventcv-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eventcv-py"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 
 [lib]

--- a/crates/eventcv-py/src/lib.rs
+++ b/crates/eventcv-py/src/lib.rs
@@ -7,7 +7,10 @@ use eventcv_core::{
     cluster::ClusterError,
     flow::FlowError,
     image::{PoolingMethod, ResizeError},
-    io::{open as open_reader, ColumnOrder, IoError, LoadOptions, Reader, SaveOptions, TimeUnit},
+    io::{
+        load_rows, open as open_reader, ColumnOrder, IoError, LoadOptions, RawRow, Reader,
+        SaveOptions, TimeUnit,
+    },
     representation::{
         AveragedTimeSurface, Binary, EventCount, EventFrame, EventFrameData, EventPointSet, Mcts,
         PointSet, Polarity, Representation, RepresentationError, Tencode, TimeSurface, VoxelGrid,
@@ -15,6 +18,7 @@ use eventcv_core::{
     viz::Colormap,
     EventStream, EventStreamBuilder,
 };
+use numpy::ndarray::Array2;
 use numpy::{IntoPyArray, PyArray2, PyReadonlyArray2};
 use pyo3::exceptions::{
     PyFileNotFoundError, PyIndexError, PyOSError, PyRuntimeError, PyTypeError, PyValueError,
@@ -243,12 +247,12 @@ impl PyEventStream {
             .map_err(map_flow_error)
     }
 
-    #[pyo3(signature = (representation=None, *, normalize=true, binary=false))]
+    #[pyo3(signature = (representation=None, *, normalize=None, binary=false))]
     fn flatten(
         &self,
         py: Python<'_>,
         representation: Option<&Bound<'_, PyAny>>,
-        normalize: bool,
+        normalize: Option<bool>,
         binary: bool,
     ) -> PyResult<PyEventFrame> {
         if binary {
@@ -293,9 +297,9 @@ impl PyEventStream {
             .map_err(map_representation_error)
     }
 
-    /// Event-count image — one channel of total events per pixel (both polarities). `uint64`
-    /// counts, or `uint8` rescaled to the busiest pixel when `normalize=True`.
-    #[pyo3(signature = (*, normalize=true))]
+    /// Event-count image — one channel of total events per pixel (both polarities). Raw
+    /// `uint64` counts by default; `uint8` rescaled to the busiest pixel when `normalize=True`.
+    #[pyo3(signature = (*, normalize=false))]
     fn count(&self, py: Python<'_>, normalize: bool) -> PyResult<PyEventFrame> {
         py.detach(|| EventCount::new(normalize).generate(&self.inner))
             .map(|inner| PyEventFrame { inner })
@@ -326,19 +330,20 @@ impl PyEventStream {
     /// to show — `stream.view("flow")`, `stream.view("count")`, `stream.view("voxel")`, … — or
     /// omit it to use the stream's stored representation (from `open(repr=…)`), falling back to
     /// the polarity image. (Equivalent to `stream.<repr>().view()`.)
-    #[pyo3(signature = (representation=None, *, colormap="viridis", normalize=true))]
+    #[pyo3(signature = (representation=None, *, colormap="viridis", normalize=None))]
     fn view(
         &self,
         py: Python<'_>,
         representation: Option<&Bound<'_, PyAny>>,
         colormap: &str,
-        normalize: bool,
+        normalize: Option<bool>,
     ) -> PyResult<()> {
         let frame = match representation {
             Some(representation) => self.generate(py, representation, normalize)?,
             None => self.default_frame(py, normalize)?,
         };
-        frame.view(py, colormap, normalize)
+        // Rendering always auto-contrasts unless the caller opts out explicitly.
+        frame.view(py, colormap, normalize.unwrap_or(true))
     }
 }
 
@@ -355,13 +360,13 @@ impl PyEventStream {
 
     /// The frame rendered when no explicit representation is passed: the stream's stored
     /// representation (from `open(repr=…)`) if set, else the default polarity image.
-    fn default_frame(&self, py: Python<'_>, normalize: bool) -> PyResult<PyEventFrame> {
+    fn default_frame(&self, py: Python<'_>, normalize: Option<bool>) -> PyResult<PyEventFrame> {
         match self.repr {
             Some(spec) => py
                 .detach(|| spec.generate(&self.inner))
                 .map(|inner| PyEventFrame { inner })
                 .map_err(map_representation_error),
-            None => self.generate_polarity(py, Polarity::new(normalize)),
+            None => self.generate_polarity(py, Polarity::new(normalize.unwrap_or(true))),
         }
     }
 
@@ -369,10 +374,10 @@ impl PyEventStream {
         &self,
         py: Python<'_>,
         representation: &Bound<'_, PyAny>,
-        normalize: bool,
+        normalize: Option<bool>,
     ) -> PyResult<PyEventFrame> {
         if representation.extract::<PyRef<'_, PyPolarity>>().is_ok() {
-            return self.generate_polarity(py, Polarity::new(normalize));
+            return self.generate_polarity(py, Polarity::new(normalize.unwrap_or(true)));
         }
         // A representation *name* ("count", "flow", "voxel", …) renders that repr with its
         // defaults — so `stream.view("flow")` / `stream.flatten("count")` read naturally.
@@ -638,8 +643,20 @@ fn us_to_ms(us: i64) -> f64 {
     us as f64 / 1000.0
 }
 
+/// Converts an `offset` argument — an absolute timestamp in ms (the file's own time base) —
+/// into microseconds. `None` and non-positive values mean "read from the start".
+fn parse_offset(offset_ms: Option<f64>) -> PyResult<Option<i64>> {
+    match offset_ms {
+        None => Ok(None),
+        Some(ms) if ms.is_nan() => Err(PyValueError::new_err("offset must be a number")),
+        Some(ms) if ms < 0.0 => Err(PyValueError::new_err("offset must be non-negative")),
+        Some(ms) => Ok(Some(ms_to_us(ms))),
+    }
+}
+
 #[pyfunction]
-#[pyo3(signature = (path, *, sensor_size=None, time_unit=None, order="txyp", topic=None, max_events=None))]
+#[pyo3(signature = (path, *, sensor_size=None, time_unit=None, order="txyp", topic=None, max_events=None, offset=None))]
+#[allow(clippy::too_many_arguments)]
 fn load(
     py: Python<'_>,
     path: &str,
@@ -648,6 +665,7 @@ fn load(
     order: &str,
     topic: Option<String>,
     max_events: Option<i64>,
+    offset: Option<f64>,
 ) -> PyResult<PyEventStream> {
     let max_events = max_events
         .map(|count| {
@@ -661,10 +679,86 @@ fn load(
         order: parse_order(order)?,
         topic,
         max_events,
+        offset: parse_offset(offset)?,
     };
     py.detach(|| eventcv_core::io::load(path, options))
         .map(|inner| PyEventStream { inner, repr: None })
         .map_err(map_io_error)
+}
+
+/// Builds an `EventStream` from an in-memory `(N, 4)` numpy array — the constructor
+/// mirror of `EventStream.numpy()`. Columns follow `order` (default `xytp`, matching
+/// `numpy()`'s output); `sensor_size` and `time_unit` are inferred exactly like `load`
+/// when omitted. Any integer or float dtype is accepted.
+#[pyfunction]
+#[pyo3(signature = (events, *, sensor_size=None, time_unit=None, order="xytp"))]
+fn from_numpy(
+    py: Python<'_>,
+    events: &Bound<'_, PyAny>,
+    sensor_size: Option<(i64, i64)>,
+    time_unit: Option<&str>,
+    order: &str,
+) -> PyResult<PyEventStream> {
+    let options = LoadOptions {
+        sensor_size: parse_sensor_size(sensor_size)?,
+        time_unit: parse_time_unit(time_unit)?,
+        order: parse_order(order)?,
+        topic: None,
+        max_events: None,
+        offset: None,
+    };
+    let rows = numpy_rows(events, options.order)?;
+    py.detach(|| load_rows(&rows, &options))
+        .map(|inner| PyEventStream { inner, repr: None })
+        .map_err(map_io_error)
+}
+
+/// Converts an `(N, ≥4)` numpy array of any int/float dtype into raw event rows laid
+/// out per `order` (extra columns are ignored, like the text loader).
+fn numpy_rows(events: &Bound<'_, PyAny>, order: ColumnOrder) -> PyResult<Vec<RawRow>> {
+    macro_rules! try_dtype {
+        ($($ty:ty),*) => {$(
+            if let Ok(array) = events.extract::<PyReadonlyArray2<$ty>>() {
+                return rows_from_view(&array.as_array().mapv(|value| value as f64), order);
+            }
+        )*};
+    }
+    try_dtype!(u64, i64, f64, u32, i32, f32, u16, i16, u8);
+    Err(PyTypeError::new_err(
+        "events must be an (N, 4) numpy array of an integer or float dtype",
+    ))
+}
+
+fn rows_from_view(view: &Array2<f64>, order: ColumnOrder) -> PyResult<Vec<RawRow>> {
+    if view.ncols() < 4 {
+        return Err(PyValueError::new_err(format!(
+            "expected an (N, 4) event array, got {} column(s)",
+            view.ncols()
+        )));
+    }
+    let (tc, xc, yc, pc) = match order {
+        ColumnOrder::Txyp => (0, 1, 2, 3),
+        ColumnOrder::Xytp => (2, 0, 1, 3),
+    };
+    let mut rows = Vec::with_capacity(view.nrows());
+    for (index, row) in view.rows().into_iter().enumerate() {
+        let coord = |value: f64, name: &str| -> PyResult<u16> {
+            let rounded = value.round();
+            if !(0.0..=f64::from(u16::MAX)).contains(&rounded) {
+                return Err(PyValueError::new_err(format!(
+                    "row {index}: {name} = {value} is not a valid sensor coordinate"
+                )));
+            }
+            Ok(rounded as u16)
+        };
+        rows.push(RawRow {
+            x: coord(row[xc], "x")?,
+            y: coord(row[yc], "y")?,
+            t: row[tc],
+            p: row[pc] > 0.0,
+        });
+    }
+    Ok(rows)
 }
 
 fn parse_dt_ms(dt_ms: Option<f64>) -> PyResult<Option<i64>> {
@@ -677,31 +771,39 @@ fn parse_dt_ms(dt_ms: Option<f64>) -> PyResult<Option<i64>> {
     }
 }
 
-/// Number of `dt`-length (µs) windows covering `[t_min, t_max]`; 0 when empty.
-fn slice_total(n_events: usize, span: (i64, i64), dt: i64) -> usize {
-    if n_events == 0 {
-        return 0;
-    }
-    let (lo, hi) = span;
-    ((hi - lo) / dt + 1) as usize
-}
-
 #[pyfunction]
-#[pyo3(signature = (path, *, dt_ms=None, repr=None, sensor_size=None, time_unit=None, order="txyp", topic=None))]
+#[pyo3(signature = (path, *, dt_ms=None, max_events=None, offset=None, repr=None, sensor_size=None, time_unit=None, order="txyp", topic=None))]
 #[allow(clippy::too_many_arguments)]
 fn open(
     py: Python<'_>,
     path: &str,
     dt_ms: Option<f64>,
+    max_events: Option<i64>,
+    offset: Option<f64>,
     repr: Option<&str>,
     sensor_size: Option<(i64, i64)>,
     time_unit: Option<&str>,
     order: &str,
     topic: Option<String>,
 ) -> PyResult<PyEventReader> {
-    let dt_us = parse_dt_ms(dt_ms)?;
+    let mode = match (parse_dt_ms(dt_ms)?, max_events) {
+        (Some(_), Some(_)) => {
+            return Err(PyValueError::new_err(
+                "pass either dt_ms (fixed-duration slices) or max_events (fixed-count slices), not both",
+            ))
+        }
+        (Some(dt), None) => Some(SliceMode::Duration(dt)),
+        (None, Some(len)) => Some(SliceMode::Count(
+            usize::try_from(len)
+                .ok()
+                .filter(|&len| len >= 1)
+                .ok_or_else(|| PyValueError::new_err("max_events must be at least 1"))?,
+        )),
+        (None, None) => None,
+    };
+    let offset_us = parse_offset(offset)?;
     let repr = repr
-        .map(|name| ReprSpec::new(name, None, None, None, None, None, true))
+        .map(|name| ReprSpec::new(name, None, None, None, None, None, None))
         .transpose()?;
     let options = LoadOptions {
         sensor_size: parse_sensor_size(sensor_size)?,
@@ -709,15 +811,33 @@ fn open(
         order: parse_order(order)?,
         topic,
         max_events: None,
+        offset: None,
     };
     let reader = py
         .detach(|| open_reader(path, options))
         .map_err(map_io_error)?;
+    // Translate the absolute offset timestamp into a base event index for fixed-count framing:
+    // the events before it are the prefix `slice(0)` must skip. Duration framing needs no index
+    // (its windows start at the origin timestamp), so this read only runs for count mode.
+    let base_index = match (offset_us, mode) {
+        (Some(origin), Some(SliceMode::Count(_))) => {
+            let (lo, _) = reader.time_span();
+            let origin = origin.max(lo);
+            if origin > lo {
+                reader.slice_time(lo, origin).map_err(map_io_error)?.len()
+            } else {
+                0
+            }
+        }
+        _ => 0,
+    };
     Ok(PyEventReader {
         inner: Arc::new(Mutex::new(reader)),
-        dt_us,
+        mode,
         repr,
         slice_op: None,
+        offset_us,
+        base_index,
     })
 }
 
@@ -728,14 +848,22 @@ fn open(
 #[pyclass(name = "EventReader", frozen)]
 struct PyEventReader {
     inner: Arc<Mutex<Reader>>,
-    /// Fixed slice duration in µs from `open(dt_ms=…)`; enables integer `slice(n)`.
-    dt_us: Option<i64>,
+    /// How the recording is partitioned into frames from `open(dt_ms=…)` /
+    /// `open(max_events=…)`; enables integer `slice(n)`.
+    mode: Option<SliceMode>,
     /// Per-slice dense rendering set by `open(repr=…)` / `with_repr` — makes the reader a
     /// map-style dataset (`reader[i]` → `[C, H, W]`, `batch` → `[B, C, H, W]`).
     repr: Option<ReprSpec>,
     /// Per-slice stream op set by `efast`/`harris_corners` — applied to every slice before any
     /// `repr`, so corner detection composes with `slice`/`windows`/`with_repr`.
     slice_op: Option<SliceOp>,
+    /// `open(offset=…)`: the absolute framing origin (µs, the file's own time base). `slice(0)` /
+    /// `windows()` / `n_slices` all start here (clamped up to `t_min`); events before it are
+    /// outside every indexed frame. `None` frames the whole recording from `t_min`.
+    offset_us: Option<i64>,
+    /// The event index of the first event at/after the offset origin — the fixed-count framing
+    /// counterpart of `offset_us` (0 for duration mode, no offset, or an offset past the end).
+    base_index: usize,
 }
 
 /// A per-slice `EventStream` → `EventStream` operation a reader carries (Phase 5 corner
@@ -763,16 +891,47 @@ fn apply_slice_op(op: Option<SliceOp>, stream: EventStream) -> EventStream {
     }
 }
 
+/// How `slice(n)` / `reader[n]` / `windows()` partition the recording: fixed-duration
+/// frames (`open(dt_ms=…)`, µs) or fixed-count frames (`open(max_events=…)`).
+#[derive(Clone, Copy)]
+enum SliceMode {
+    Duration(i64),
+    Count(usize),
+}
+
+/// One resolved slice: a half-open time window (µs) or event-index range.
+#[derive(Clone, Copy)]
+enum SliceWindow {
+    Time(i64, i64),
+    Index(usize, usize),
+}
+
+/// Reads `window` from the shared reader off-GIL, applying the per-slice op.
+fn fetch_window(
+    py: Python<'_>,
+    reader: &Arc<Mutex<Reader>>,
+    window: SliceWindow,
+    op: Option<SliceOp>,
+) -> PyResult<EventStream> {
+    let reader = Arc::clone(reader);
+    py.detach(move || {
+        let guard = reader.lock().unwrap();
+        match window {
+            SliceWindow::Time(t0, t1) => guard.slice_time(t0, t1),
+            SliceWindow::Index(i0, i1) => guard.slice_index(i0, i1),
+        }
+        .map(|stream| apply_slice_op(op, stream))
+    })
+    .map_err(map_io_error)
+}
+
 #[pymethods]
 impl PyEventReader {
-    /// `n_slices` in the `dt_ms` frame-dataset mode (so `len(reader) == len(reader[:])`),
-    /// else the raw event count. Lets `DataLoader` iterate the reader directly.
+    /// `n_slices` in the `dt_ms` / `max_events` frame-dataset modes (so `len(reader) ==
+    /// len(reader[:])`), else the raw event count. Lets `DataLoader` iterate the reader directly.
     fn __len__(&self) -> PyResult<usize> {
-        match self.dt_us {
-            Some(dt) => {
-                let guard = self.inner.lock().unwrap();
-                Ok(slice_total(guard.n_events(), guard.time_span(), dt))
-            }
+        match self.mode {
+            Some(mode) => Ok(self.frame_count(mode)),
             None => Ok(self.inner.lock().unwrap().n_events()),
         }
     }
@@ -805,25 +964,45 @@ impl PyEventReader {
         us_to_ms(hi - lo)
     }
 
-    /// Number of fixed `dt_ms` slices spanning the recording (requires `open(dt_ms=…)`).
+    /// Number of fixed slices spanning the recording (requires `open(dt_ms=…)` or
+    /// `open(max_events=…)`).
     #[getter]
     fn n_slices(&self) -> PyResult<usize> {
-        let dt = self.require_dt()?;
-        let guard = self.inner.lock().unwrap();
-        Ok(slice_total(guard.n_events(), guard.time_span(), dt))
+        let mode = self.require_mode()?;
+        Ok(self.frame_count(mode))
     }
 
     /// The fixed slice duration set at `open`, or `None` if it was not given.
     #[getter]
     fn dt_ms(&self) -> Option<f64> {
-        self.dt_us.map(us_to_ms)
+        match self.mode {
+            Some(SliceMode::Duration(dt)) => Some(us_to_ms(dt)),
+            _ => None,
+        }
+    }
+
+    /// The fixed events-per-slice set at `open(max_events=…)`, or `None` if it was not given.
+    #[getter]
+    fn max_events(&self) -> Option<usize> {
+        match self.mode {
+            Some(SliceMode::Count(len)) => Some(len),
+            _ => None,
+        }
+    }
+
+    /// The absolute framing origin (ms, the file's time base) set at `open(offset=…)`, or
+    /// `None` if it was not given.
+    #[getter]
+    fn offset(&self) -> Option<f64> {
+        self.offset_us.map(us_to_ms)
     }
 
     /// One slice as an `EventStream`. With a positional index `n` (requires
-    /// `open(dt_ms=…)`), returns the `n`-th fixed `dt_ms` frame measured from the
-    /// recording start — `[t_min + n·dt, t_min + (n+1)·dt)`; negative `n` counts from
-    /// the end. Otherwise returns the half-open time window `[t0_ms, t1_ms)`, with
-    /// omitted bounds extending to the recording's start / end.
+    /// `open(dt_ms=…)` or `open(max_events=…)`), returns the `n`-th fixed frame — the
+    /// `dt_ms`-long window `[t_min + n·dt, t_min + (n+1)·dt)`, or the `max_events`-sized
+    /// event chunk `[n·N, (n+1)·N)`; negative `n` counts from the end. Otherwise returns
+    /// the half-open time window `[t0_ms, t1_ms)`, with omitted bounds extending to the
+    /// recording's start / end.
     #[pyo3(signature = (index=None, *, t0_ms=None, t1_ms=None))]
     fn slice(
         &self,
@@ -832,7 +1011,7 @@ impl PyEventReader {
         t0_ms: Option<f64>,
         t1_ms: Option<f64>,
     ) -> PyResult<PyEventStream> {
-        let (t0, t1) = if let Some(index) = index {
+        let window = if let Some(index) = index {
             if t0_ms.is_some() || t1_ms.is_some() {
                 return Err(PyValueError::new_err(
                     "pass either a slice index or t0_ms/t1_ms, not both",
@@ -841,21 +1020,21 @@ impl PyEventReader {
             self.window_for_index(index)?
         } else {
             let (lo, hi) = self.inner.lock().unwrap().time_span();
-            (
+            SliceWindow::Time(
                 t0_ms.map_or(lo, ms_to_us),
                 t1_ms.map_or(hi.saturating_add(1), ms_to_us), // +1 keeps the last event
             )
         };
-        self.fetch_time(py, t0, t1)
+        self.fetch(py, window)
     }
 
-    /// `reader[n]` — the `n`-th `dt_ms` frame (requires `open(dt_ms=…)`). Without a
-    /// representation it returns the raw `EventStream` (like `slice(n)`); with one set
-    /// (`open(repr=…)` / `with_repr`) it returns the dense `[C, H, W]` array, so a
-    /// `torch.utils.data.DataLoader` can collate the reader directly.
+    /// `reader[n]` — the `n`-th fixed frame (requires `open(dt_ms=…)` or
+    /// `open(max_events=…)`). Without a representation it returns the raw `EventStream`
+    /// (like `slice(n)`); with one set (`open(repr=…)` / `with_repr`) it returns the dense
+    /// `[C, H, W]` array, so a `torch.utils.data.DataLoader` can collate the reader directly.
     fn __getitem__(&self, py: Python<'_>, index: i64) -> PyResult<Py<PyAny>> {
-        let (t0, t1) = self.window_for_index(index)?;
-        let stream = self.fetch_time(py, t0, t1)?;
+        let window = self.window_for_index(index)?;
+        let stream = self.fetch(py, window)?;
         match self.repr {
             Some(spec) => {
                 let frame = py
@@ -870,7 +1049,7 @@ impl PyEventReader {
     /// Returns a new reader over the same file that renders each slice with `repr` (unset
     /// params take their method defaults). The dataset-mode counterpart of `open(repr=…)`,
     /// but with per-representation options: e.g. `reader.with_repr("voxel", bins=5)`.
-    #[pyo3(signature = (repr, *, bins=None, window_ms=None, tau_ms=None, max_window_ms=None, window=None, normalize=true))]
+    #[pyo3(signature = (repr, *, bins=None, window_ms=None, tau_ms=None, max_window_ms=None, window=None, normalize=None))]
     #[allow(clippy::too_many_arguments)]
     fn with_repr(
         &self,
@@ -880,7 +1059,7 @@ impl PyEventReader {
         tau_ms: Option<f64>,
         max_window_ms: Option<f64>,
         window: Option<i64>,
-        normalize: bool,
+        normalize: Option<bool>,
     ) -> PyResult<PyEventReader> {
         let spec = ReprSpec::new(
             repr,
@@ -893,9 +1072,11 @@ impl PyEventReader {
         )?;
         Ok(PyEventReader {
             inner: Arc::clone(&self.inner),
-            dt_us: self.dt_us,
+            mode: self.mode,
             repr: Some(spec),
             slice_op: self.slice_op,
+            offset_us: self.offset_us,
+            base_index: self.base_index,
         })
     }
 
@@ -928,18 +1109,8 @@ impl PyEventReader {
         })?;
         let mut frames = Vec::with_capacity(indices.len());
         for index in indices {
-            let (t0, t1) = self.window_for_index(index)?;
-            let reader = Arc::clone(&self.inner);
-            let op = self.slice_op;
-            let stream = py
-                .detach(move || {
-                    reader
-                        .lock()
-                        .unwrap()
-                        .slice_time(t0, t1)
-                        .map(|stream| apply_slice_op(op, stream))
-                })
-                .map_err(map_io_error)?;
+            let window = self.window_for_index(index)?;
+            let stream = fetch_window(py, &self.inner, window, self.slice_op)?;
             let frame = py
                 .detach(|| spec.generate(&stream))
                 .map_err(map_representation_error)?;
@@ -967,36 +1138,41 @@ impl PyEventReader {
             usize::try_from(i0).map_err(|_| PyValueError::new_err("i0 must be non-negative"))?;
         let i1 =
             usize::try_from(i1).map_err(|_| PyValueError::new_err("i1 must be non-negative"))?;
-        let reader = Arc::clone(&self.inner);
-        let op = self.slice_op;
-        py.detach(move || {
-            reader
-                .lock()
-                .unwrap()
-                .slice_index(i0, i1)
-                .map(|stream| apply_slice_op(op, stream))
-        })
-        .map(|inner| PyEventStream {
-            inner,
-            repr: self.repr,
-        })
-        .map_err(map_io_error)
+        self.fetch(py, SliceWindow::Index(i0, i1))
     }
 
     /// Lazy iterator of consecutive windows: each is `[start, start + span_ms)` and
     /// `start` advances by `step_ms`. `step_ms` defaults to the `dt_ms` set at `open`
     /// (so `windows()` walks every `slice(n)`), and `span_ms` defaults to `step_ms`
-    /// (non-overlapping). Streams a multi-GB file window-by-window without loading it.
+    /// (non-overlapping). For a `max_events` reader, `windows()` without arguments walks
+    /// the fixed-count slices instead. Streams a multi-GB file window-by-window without
+    /// loading it.
     #[pyo3(signature = (*, step_ms=None, span_ms=None))]
     fn windows(&self, step_ms: Option<f64>, span_ms: Option<f64>) -> PyResult<PyWindowIterator> {
+        let guard = self.inner.lock().unwrap();
+        let (lo, hi) = guard.time_span();
+        let n_events = guard.n_events();
+        drop(guard);
+        if let (None, None, Some(SliceMode::Count(len))) = (step_ms, span_ms, self.mode) {
+            return Ok(self.window_iterator(WindowCursor::Index {
+                next: self.base_index,
+                len,
+                total: n_events,
+            }));
+        }
         let step_us = match step_ms {
             Some(ms) if ms.is_nan() || ms <= 0.0 => {
                 return Err(PyValueError::new_err("step_ms must be positive"))
             }
             Some(ms) => ms_to_us(ms).max(1),
-            None => self.dt_us.ok_or_else(|| {
-                PyValueError::new_err("windows() needs step_ms, or open the file with dt_ms")
-            })?,
+            None => match self.mode {
+                Some(SliceMode::Duration(dt)) => dt,
+                _ => {
+                    return Err(PyValueError::new_err(
+                        "windows() needs step_ms, or open the file with dt_ms",
+                    ))
+                }
+            },
         };
         let span_us = match span_ms {
             Some(ms) if ms.is_nan() || ms <= 0.0 => {
@@ -1005,76 +1181,106 @@ impl PyEventReader {
             Some(ms) => ms_to_us(ms).max(1),
             None => step_us,
         };
-        let guard = self.inner.lock().unwrap();
-        let (lo, hi) = guard.time_span();
-        let empty = guard.n_events() == 0;
-        drop(guard);
-        Ok(PyWindowIterator {
-            reader: Arc::clone(&self.inner),
-            cursor: lo,
+        Ok(self.window_iterator(WindowCursor::Time {
+            next: self.origin(lo),
             step_us,
             span_us,
-            end: if empty { i64::MIN } else { hi },
-            slice_op: self.slice_op,
-            repr: self.repr,
-        })
+            end: if n_events == 0 { i64::MIN } else { hi },
+        }))
     }
 }
 
 impl PyEventReader {
-    /// Reads the half-open time window `[t0, t1)` (µs) off-GIL into an `EventStream`, applying the
-    /// reader's per-slice op (e.g. `efast`) if one is set.
-    fn fetch_time(&self, py: Python<'_>, t0: i64, t1: i64) -> PyResult<PyEventStream> {
-        let reader = Arc::clone(&self.inner);
-        let op = self.slice_op;
-        py.detach(move || {
-            reader
-                .lock()
-                .unwrap()
-                .slice_time(t0, t1)
-                .map(|stream| apply_slice_op(op, stream))
-        })
-        .map(|inner| PyEventStream {
+    /// Reads `window` off-GIL into an `EventStream` carrying the reader's stored repr,
+    /// applying the per-slice op (e.g. `efast`) if one is set.
+    fn fetch(&self, py: Python<'_>, window: SliceWindow) -> PyResult<PyEventStream> {
+        fetch_window(py, &self.inner, window, self.slice_op).map(|inner| PyEventStream {
             inner,
             repr: self.repr,
         })
-        .map_err(map_io_error)
     }
 
-    /// A new reader over the same file (and `dt`/`repr`) that applies `op` to every slice.
+    /// A new reader over the same file (and mode/`repr`) that applies `op` to every slice.
     fn with_slice_op(&self, op: SliceOp) -> PyEventReader {
         PyEventReader {
             inner: Arc::clone(&self.inner),
-            dt_us: self.dt_us,
+            mode: self.mode,
             repr: self.repr,
             slice_op: Some(op),
+            offset_us: self.offset_us,
+            base_index: self.base_index,
         }
     }
 
-    fn require_dt(&self) -> PyResult<i64> {
-        self.dt_us.ok_or_else(|| {
+    /// An iterator over this reader's file starting at `cursor` (shares op/repr).
+    fn window_iterator(&self, cursor: WindowCursor) -> PyWindowIterator {
+        PyWindowIterator {
+            reader: Arc::clone(&self.inner),
+            cursor,
+            slice_op: self.slice_op,
+            repr: self.repr,
+        }
+    }
+
+    fn require_mode(&self) -> PyResult<SliceMode> {
+        self.mode.ok_or_else(|| {
             PyValueError::new_err(
-                "reader was opened without dt_ms; pass open(path, dt_ms=…) to use integer slice indices",
+                "reader was opened without dt_ms or max_events; pass open(path, dt_ms=…) or open(path, max_events=…) to use integer slice indices",
             )
         })
     }
 
-    /// The `[t0, t1)` window (µs) for the `index`-th `dt` slice, validating the range
-    /// (negative indices count back from the end).
-    fn window_for_index(&self, index: i64) -> PyResult<(i64, i64)> {
-        let dt = self.require_dt()?;
+    /// The window for the `index`-th slice under the reader's mode, validating the range
+    /// (negative indices count back from the end). Framing starts at the offset origin
+    /// (`t_min + offset` for duration mode, `base_index` for count mode).
+    fn window_for_index(&self, index: i64) -> PyResult<SliceWindow> {
+        let mode = self.require_mode()?;
         let guard = self.inner.lock().unwrap();
-        let total = slice_total(guard.n_events(), guard.time_span(), dt) as i64;
-        let (lo, _hi) = guard.time_span();
+        let (n_events, (lo, _)) = (guard.n_events(), guard.time_span());
         drop(guard);
+        let total = self.frame_count(mode) as i64;
         let resolved = if index < 0 { index + total } else { index };
         if resolved < 0 || resolved >= total {
             return Err(PyIndexError::new_err(format!(
                 "slice index {index} out of range for {total} slices"
             )));
         }
-        let t0 = lo + resolved * dt;
-        Ok((t0, t0 + dt))
+        Ok(match mode {
+            SliceMode::Duration(dt) => {
+                let t0 = self.origin(lo) + resolved * dt;
+                SliceWindow::Time(t0, t0 + dt)
+            }
+            SliceMode::Count(len) => {
+                let i0 = self.base_index + resolved as usize * len;
+                SliceWindow::Index(i0, (i0 + len).min(n_events))
+            }
+        })
+    }
+
+    /// Number of fixed frames under `mode`, measured from the offset origin: duration frames
+    /// spanning `[t_min + offset, t_max]`, or count frames over the events at/after `base_index`.
+    fn frame_count(&self, mode: SliceMode) -> usize {
+        let guard = self.inner.lock().unwrap();
+        let (lo, hi) = guard.time_span();
+        let n_events = guard.n_events();
+        drop(guard);
+        match mode {
+            SliceMode::Duration(dt) => {
+                let origin = self.origin(lo);
+                if n_events == 0 || origin > hi {
+                    0
+                } else {
+                    ((hi - origin) / dt + 1) as usize
+                }
+            }
+            SliceMode::Count(len) => n_events.saturating_sub(self.base_index).div_ceil(len),
+        }
+    }
+
+    /// The absolute framing origin (µs) given the recording's `t_min` (`lo`): the offset
+    /// timestamp clamped up to `t_min`, or `t_min` itself when no offset was set.
+    fn origin(&self, lo: i64) -> i64 {
+        self.offset_us.map_or(lo, |offset| offset.max(lo))
     }
 }
 
@@ -1082,14 +1288,56 @@ impl PyEventReader {
 #[pyclass]
 struct PyWindowIterator {
     reader: Arc<Mutex<Reader>>,
-    cursor: i64,
-    step_us: i64,
-    span_us: i64,
-    end: i64,
+    cursor: WindowCursor,
     slice_op: Option<SliceOp>,
     /// The reader's stored representation, carried onto each yielded window (so `open(repr=…)`
     /// survives `for w in reader.windows(): w.view()`).
     repr: Option<ReprSpec>,
+}
+
+/// Walks a recording as consecutive time windows (`windows(step_ms=…)` / `dt_ms`
+/// readers) or fixed-count event chunks (`max_events` readers).
+enum WindowCursor {
+    Time {
+        next: i64,
+        step_us: i64,
+        span_us: i64,
+        end: i64,
+    },
+    Index {
+        next: usize,
+        len: usize,
+        total: usize,
+    },
+}
+
+impl WindowCursor {
+    /// The next window to fetch, advancing the cursor; `None` when exhausted.
+    fn advance(&mut self) -> Option<SliceWindow> {
+        match self {
+            Self::Time {
+                next,
+                step_us,
+                span_us,
+                end,
+            } => {
+                if *next > *end {
+                    return None;
+                }
+                let t0 = *next;
+                *next = next.saturating_add(*step_us);
+                Some(SliceWindow::Time(t0, t0.saturating_add(*span_us)))
+            }
+            Self::Index { next, len, total } => {
+                if *next >= *total {
+                    return None;
+                }
+                let i0 = *next;
+                *next = i0 + *len;
+                Some(SliceWindow::Index(i0, (i0 + *len).min(*total)))
+            }
+        }
+    }
 }
 
 #[pymethods]
@@ -1099,23 +1347,10 @@ impl PyWindowIterator {
     }
 
     fn __next__(&mut self, py: Python<'_>) -> PyResult<Option<PyEventStream>> {
-        if self.cursor > self.end {
+        let Some(window) = self.cursor.advance() else {
             return Ok(None);
-        }
-        let t0 = self.cursor;
-        let t1 = t0.saturating_add(self.span_us);
-        self.cursor = self.cursor.saturating_add(self.step_us);
-        let reader = Arc::clone(&self.reader);
-        let op = self.slice_op;
-        let stream = py
-            .detach(move || {
-                reader
-                    .lock()
-                    .unwrap()
-                    .slice_time(t0, t1)
-                    .map(|stream| apply_slice_op(op, stream))
-            })
-            .map_err(map_io_error)?;
+        };
+        let stream = fetch_window(py, &self.reader, window, self.slice_op)?;
         Ok(Some(PyEventStream {
             inner: stream,
             repr: self.repr,
@@ -1325,7 +1560,7 @@ enum ReprSpec {
 
 impl ReprSpec {
     /// Builds a spec from a repr name and the optional overrides (unset ones take the
-    /// same defaults as the `EventStream` methods).
+    /// same defaults as the `EventStream` methods: count raw `u64`, polarity normalized).
     fn new(
         name: &str,
         bins: Option<i64>,
@@ -1333,12 +1568,16 @@ impl ReprSpec {
         tau_ms: Option<f64>,
         max_window_ms: Option<f64>,
         window: Option<i64>,
-        normalize: bool,
+        normalize: Option<bool>,
     ) -> PyResult<Self> {
         Ok(match name {
             "binary" => Self::Binary,
-            "count" => Self::Count { normalize },
-            "polarity" => Self::Polarity { normalize },
+            "count" => Self::Count {
+                normalize: normalize.unwrap_or(false),
+            },
+            "polarity" => Self::Polarity {
+                normalize: normalize.unwrap_or(true),
+            },
             "voxel" => Self::Voxel {
                 bins: bins
                     .map(|value| {
@@ -1428,6 +1667,7 @@ fn _rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyPolarity>()?;
     m.add_class::<PyCamera>()?;
     m.add_function(wrap_pyfunction!(load, m)?)?;
+    m.add_function(wrap_pyfunction!(from_numpy, m)?)?;
     m.add_function(wrap_pyfunction!(open, m)?)?;
     m.add_function(wrap_pyfunction!(save, m)?)?;
     m.add_function(wrap_pyfunction!(load_frame, m)?)?;

--- a/docs/api.md
+++ b/docs/api.md
@@ -11,6 +11,7 @@ below); the free functions are generated from the methods, so the two forms stay
 .. currentmodule:: eventcv
 
 .. autofunction:: load
+.. autofunction:: from_numpy
 .. autofunction:: open
 .. autofunction:: save
 .. autofunction:: load_frame
@@ -48,5 +49,5 @@ introspecting the compiled types, so this list always matches the methods above.
 .. automodule:: eventcv
    :members:
    :exclude-members: EventStream, EventFrame, EventReader, EventPointSet, Camera,
-      Polarity, FrameSink, load, open, save, load_frame, export_png, collate
+      Polarity, FrameSink, load, from_numpy, open, save, load_frame, export_png, collate
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -11,7 +11,26 @@ import eventcv as ecv
 stream = ecv.load("recording.hdf5")
 print(stream.sensor_size)      # (width, height)
 print(len(stream))             # number of events
-events = stream.numpy()        # N×4 array of [t, x, y, p]
+events = stream.numpy()        # N×4 array of [x, y, t, p]
+```
+
+To read only part of a large recording, `offset` skips events before an **absolute
+timestamp** (in milliseconds, the file's own time base) and `max_events` caps how many are
+kept after it:
+
+```python
+window = ecv.load("recording.hdf5", offset=1_000, max_events=500_000)   # from t = 1 s on
+```
+
+Already have events in memory (e.g. from another tool)? {func}`eventcv.from_numpy` is the
+inverse of `numpy()` — build a stream from an `(N, 4)` array. Columns default to `xytp`
+(what `numpy()` emits); sensor size and time unit are inferred when omitted:
+
+```python
+import numpy as np
+
+events = np.array([[0, 0, 100, 1], [1, 2, 250, 0]])   # x y t p
+stream = ecv.from_numpy(events, time_unit="us")
 ```
 
 ## Transform (chainable, functional)
@@ -44,6 +63,29 @@ reader = ecv.open("huge.hdf5", dt_ms=30)   # treat as 30 ms frames
 print(reader.n_slices)
 frame = reader.slice(50).voxel()           # the 50th 30 ms frame → voxel grid
 ```
+
+Slice by a fixed **event count** instead of a fixed duration with `max_events` — each
+slice holds exactly that many consecutive events (the last may be shorter), which keeps
+the number of events per frame constant rather than the time span. It is mutually
+exclusive with `dt_ms`:
+
+```python
+reader = ecv.open("huge.hdf5", max_events=10_000)   # 10k-event frames
+frame = reader.slice(50).voxel()                    # the 50th 10k-event frame
+```
+
+Pass `offset` — an **absolute timestamp in milliseconds** (the same time base as
+`slice(t0_ms=…)`) — to move the framing origin: `slice(0)`, `windows()`, and `n_slices` all
+begin at that time, and earlier events fall outside every frame. It composes with either
+`dt_ms` or `max_events`:
+
+```python
+reader = ecv.open("huge.hdf5", dt_ms=30, offset=1_000)   # frame 0 starts at t = 1 s
+```
+
+For a recording whose timestamps are epoch-based, `offset` is just that epoch time in ms
+(e.g. `offset=1_587_540_271_650`). Values before the recording clamp to the start; values
+past the end give zero frames.
 
 Pass `repr=` to give the reader a **default representation**. It is remembered by every
 slice, so `slice(n).view()` renders it (no need to name it again), and it makes the reader

--- a/docs/representations.md
+++ b/docs/representations.md
@@ -39,8 +39,10 @@ neither is a valid `repr=` / `flatten` / `view` name. See their sections below.
 
 The dtype column lists `uint64`/`uint8` for the two representations with a `normalize` option
 (`count` and `polarity`): raw `uint64` counts, or `uint8` rescaled so the busiest pixel maps to
-255 when `normalize=True` (the default in every Python entry point). The rest have no
-normalization option.
+255 when `normalize=True`. The default differs by representation: `polarity` normalizes by
+default (`True`), while `count` returns raw counts by default (`False`) so the frame preserves
+exact event totals. The rest have no normalization option. `view` always auto-contrasts for
+display regardless of the frame's dtype.
 
 ## Polarity
 
@@ -70,15 +72,17 @@ No parameters, and — like `polarity` — no dedicated method; only reachable v
 ## Count
 
 ```python
-stream.count(normalize=True)
-ecv.count(stream, normalize=False)
+stream.count()                    # raw uint64 counts (default)
+ecv.count(stream, normalize=True) # uint8, busiest pixel → 255
 ```
 
-- `normalize` (`bool`, default `True`) — rescale to `uint8` (busiest pixel → 255) instead of
-  raw `uint64` counts.
+- `normalize` (`bool`, default `False`) — when `True`, rescale to `uint8` (busiest pixel → 255)
+  instead of the default raw `uint64` counts.
 
 Single channel: total events per pixel, both polarities summed. The plainest "how much
-happened here" frame — unlike `polarity`, it collapses polarity into one intensity map.
+happened here" frame — unlike `polarity`, it collapses polarity into one intensity map. The raw
+`uint64` default keeps exact totals (e.g. `count().numpy().sum()` equals the event count), which
+is what you want for analysis; pass `normalize=True` for a display-scaled image.
 
 ## Voxel grid
 
@@ -204,8 +208,10 @@ and `reader.with_repr(...)`. The name is one of `"polarity"`, `"binary"`, `"coun
 parameters — they don't accept a representation's own parameters (`bins`, `tau_ms`, `window_ms`,
 `max_window_ms`, `window`), so `stream.flatten("voxel", bins=5)` is a `TypeError`. The one
 exception is `normalize`, which is an argument of `flatten`/`view` themselves, so
-`stream.flatten("count", normalize=False)` does work. To override the other parameters by name,
-use `reader.with_repr(name, **opts)`, which returns a new dataset reader:
+`stream.flatten("count", normalize=True)` does work (and each representation keeps its own
+`normalize` default when the argument is omitted — `False` for `count`, `True` for `polarity`).
+To override the other parameters by name, use `reader.with_repr(name, **opts)`, which returns a
+new dataset reader:
 
 ```python
 # defaults, by name:

--- a/docs/tutorials/01-getting-started.ipynb
+++ b/docs/tutorials/01-getting-started.ipynb
@@ -131,7 +131,7 @@
      "output_type": "stream",
      "text": [
       "kind: count\n",
-      "shape (C, H, W): (1, 480, 640) uint8\n"
+      "shape (C, H, W): (1, 480, 640) uint64\n"
      ]
     }
    ],

--- a/docs/tutorials/02-transforms-and-representations.ipynb
+++ b/docs/tutorials/02-transforms-and-representations.ipynb
@@ -161,7 +161,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "count            (1, 240, 320)      uint8\n",
+      "count            (1, 240, 320)      uint64\n",
       "voxel(bins=5)    (5, 240, 320)      float32\n",
       "time surface     (2, 240, 320)      float32\n"
      ]
@@ -203,7 +203,7 @@
      "output_type": "stream",
      "text": [
       "frames: 3\n",
-      "ds[0]: (1, 480, 640) uint8\n",
+      "ds[0]: (1, 480, 640) uint64\n",
       "batch([0, 1]): (2, 1, 480, 640)\n"
      ]
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "maturin"
 
 [project]
 name = "eventcv"
-version = "1.0.0"
+version = "1.0.1"
 description = "Open source event-based computer vision library."
 readme = "README.md"
 requires-python = ">=3.9"
@@ -15,7 +15,7 @@ authors = [
   { name = "Adam Hines", email = "a.david.hines@gmail.com"}
 ]
 dependencies = [
-    "numpy>=1.24,<2"
+    "numpy"
 ]
 
 # Test-only tools (writing/inspecting HDF5 fixtures). Not needed to use eventcv —

--- a/python/eventcv/load.py
+++ b/python/eventcv/load.py
@@ -18,6 +18,7 @@ def load(
     order: str = "txyp",
     topic: str | None = None,
     max_events: int | None = None,
+    offset: float | None = None,
 ) -> EventStream:
     """Load events from any supported file, detected by its extension.
 
@@ -31,8 +32,12 @@ def load(
     from the coordinate range. Passing ``sensor_size`` for HDF5 also skips that scan.
     ``time_unit`` is ``seconds``/``milliseconds``/``microseconds``/``nanoseconds`` (or
     ``auto``); ``order`` (``txyp``/``xytp``) applies to text. ``topic`` selects the
-    rosbag topic (default ``/davis/left/events``). ``max_events`` caps how many events
-    are read, handy for previewing very large files.
+    rosbag topic (default ``/davis/left/events``). ``offset`` is an **absolute timestamp
+    in milliseconds** (the file's own time base — the same base as ``stream.numpy()[:, 2]``
+    scaled to ms): events before it are skipped, and ``max_events`` then caps how many are
+    kept *after* it — together they read a window, handy for previewing a slice of a very
+    large file. For a recording whose timestamps are epoch-based, pass the epoch time in ms
+    (e.g. ``offset=1_587_540_271_650``); ``<= 0`` reads from the start.
     """
     return _rust.load(
         path,
@@ -41,6 +46,43 @@ def load(
         order=order,
         topic=topic,
         max_events=max_events,
+        offset=offset,
+    )
+
+
+def from_numpy(
+    events,
+    *,
+    sensor_size: tuple[int, int] | None = None,
+    time_unit: str | None = None,
+    order: str = "xytp",
+) -> EventStream:
+    """Build an :class:`EventStream` from an in-memory ``(N, 4)`` NumPy array.
+
+    The constructor mirror of :meth:`EventStream.numpy`: ``order`` defaults to ``xytp``
+    (the column layout ``numpy()`` emits, with timestamps in microseconds), so
+    ``ecv.from_numpy(stream.numpy(), time_unit="us")`` round-trips a stream. Pass
+    ``order="txyp"`` for arrays in the common ``t x y p`` dataset layout. Any integer or
+    float dtype is accepted; polarity is positive when its value is greater than zero
+    (both ``0/1`` and ``-1/1`` conventions work).
+
+    ``sensor_size`` and ``time_unit`` are **auto-detected** when omitted, exactly like
+    :func:`load`: the sensor is the smallest grid holding every event, and the time unit
+    is inferred from the timestamp span (fractional values mean seconds; the inference
+    assumes a recording of at least ~1 s, so pass ``time_unit`` explicitly for short
+    arrays). Events outside an explicit ``sensor_size`` are dropped.
+
+    Example::
+
+        events = np.array([[0, 0, 100, 1], [1, 2, 250, 0]])   # x y t p
+        stream = ecv.from_numpy(events, time_unit="us")
+        stream.count().numpy()
+    """
+    return _rust.from_numpy(
+        events,
+        sensor_size=sensor_size,
+        time_unit=time_unit,
+        order=order,
     )
 
 
@@ -48,6 +90,8 @@ def open(
     path: str,
     *,
     dt_ms: float | None = None,
+    max_events: int | None = None,
+    offset: float | None = None,
     repr: str | None = None,
     sensor_size: tuple[int, int] | None = None,
     time_unit: str | None = None,
@@ -66,8 +110,20 @@ def open(
     Pass ``dt_ms`` to treat the recording as a sequence of fixed-duration frames: the
     reader reports ``n_slices`` and ``reader.slice(n)`` returns the ``n``-th frame
     (``reader[n]`` works too). Frame ``n`` is measured from the recording start, so you
-    never deal with absolute timestamps (which may be epoch-based). Without ``dt_ms``,
-    slice by explicit time/count window instead.
+    never deal with absolute timestamps (which may be epoch-based). ``max_events`` is
+    the event-count twin: ``open(path, max_events=10_000)`` makes each slice exactly
+    10 000 consecutive events (the last one may be shorter), which keeps the event rate
+    per frame constant instead of the duration. The two are mutually exclusive — pass
+    one or the other, not both. Without either, slice by explicit time/count window
+    instead.
+
+    ``offset`` is an **absolute timestamp in milliseconds** (the file's own time base —
+    exactly what ``slice(t0_ms=…)`` takes) that moves the framing origin: ``slice(0)``,
+    ``windows()``, and ``n_slices`` all begin at that time, and events before it fall
+    outside every indexed frame. It is clamped up to ``t_min``, so an offset before the
+    recording is a no-op, and one past the end yields zero frames. For an epoch-based
+    recording pass the epoch time in ms (e.g. ``offset=1_587_540_271_650``). It composes
+    with either ``dt_ms`` or ``max_events``.
 
     ``sensor_size`` and ``time_unit`` are **auto-detected** when omitted (see
     :func:`load`); ``order``/``topic`` match :func:`load`. For a multi-GB HDF5, pass
@@ -113,6 +169,8 @@ def open(
     return _rust.open(
         path,
         dt_ms=dt_ms,
+        max_events=max_events,
+        offset=offset,
         repr=repr,
         sensor_size=sensor_size,
         time_unit=time_unit,
@@ -217,6 +275,7 @@ __all__ = [
     "Polarity",
     "collate",
     "export_png",
+    "from_numpy",
     "load",
     "load_frame",
     "open",

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -313,7 +313,7 @@ class DatasetReaderTests(unittest.TestCase):
         frame = reader[0]
         self.assertIsInstance(frame, np.ndarray)
         self.assertEqual(frame.shape, (1, 8, 8))  # count = 1 channel
-        self.assertEqual(frame.dtype, np.uint8)   # normalized by default
+        self.assertEqual(frame.dtype, np.uint64)  # raw counts by default
         # Frame 0 holds exactly the event at (0,0).
         self.assertEqual(frame.sum(), frame[0, 0, 0])
 
@@ -354,7 +354,7 @@ class DatasetReaderTests(unittest.TestCase):
         reader = self._dataset()
         batch = reader.batch([0, 2, 3])
         self.assertEqual(batch.shape, (3, 1, 8, 8))
-        self.assertEqual(batch.dtype, np.uint8)
+        self.assertEqual(batch.dtype, np.uint64)
         # Each row matches the corresponding single-index render.
         for row, index in enumerate([0, 2, 3]):
             np.testing.assert_array_equal(batch[row], reader[index])
@@ -376,8 +376,102 @@ class DatasetReaderTests(unittest.TestCase):
         reader = self._dataset()
         seen = [reader[i] for i in range(len(reader))]
         self.assertEqual(len(seen), 4)
-        total_events = sum(int(frame.sum()) for frame in seen)  # normalized counts
-        self.assertGreater(total_events, 0)
+        # Raw counts by default, so the frames sum to exactly the file's 4 events.
+        total_events = sum(int(frame.sum()) for frame in seen)
+        self.assertEqual(total_events, 4)
+
+    def test_max_events_mode_slices_fixed_count_frames(self):
+        path = Path(tempfile.mkdtemp()) / "events.txt"
+        path.write_text("0 0 0 1\n10 1 1 0\n20 2 2 1\n30 3 3 0\n40 4 4 1\n")
+        reader = eventcv.open(str(path), max_events=2, sensor_size=(8, 8), time_unit="us")
+
+        self.assertEqual(reader.max_events, 2)
+        self.assertIsNone(reader.dt_ms)
+        self.assertEqual(reader.n_slices, 3)  # ceil(5 / 2), last slice is short
+        self.assertEqual(len(reader), 3)
+        self.assertEqual([len(reader.slice(i)) for i in range(3)], [2, 2, 1])
+        self.assertEqual(len(reader.slice(-1)), 1)  # negative indices count back
+        # Slices partition the file in order: first slice holds the first two events.
+        np.testing.assert_array_equal(reader.slice(0).numpy()[:, 2], [0, 10])
+        with self.assertRaisesRegex(IndexError, "out of range"):
+            reader.slice(3)
+        # windows() without arguments walks the same fixed-count slices.
+        self.assertEqual([len(w) for w in reader.windows()], [2, 2, 1])
+
+    def test_max_events_mode_works_as_dataset(self):
+        path = Path(tempfile.mkdtemp()) / "events.txt"
+        path.write_text("0 0 0 1\n10 1 1 0\n20 2 2 1\n30 3 3 0\n")
+        reader = eventcv.open(
+            str(path), max_events=2, repr="count", sensor_size=(8, 8), time_unit="us"
+        )
+
+        self.assertEqual(reader[0].shape, (1, 8, 8))
+        self.assertEqual(int(reader[0].sum()), 2)  # raw counts: 2 events per slice
+        self.assertEqual(reader.batch([0, 1]).shape, (2, 1, 8, 8))
+        stream = reader.slice(1)
+        self.assertEqual(stream.repr, "count")  # open(repr=…) survives count slicing
+
+    def test_open_rejects_dt_ms_with_max_events(self):
+        path = Path(tempfile.mkdtemp()) / "events.txt"
+        path.write_text("0 0 0 1\n")
+        with self.assertRaisesRegex(ValueError, "not both"):
+            eventcv.open(str(path), dt_ms=1.0, max_events=2, sensor_size=(8, 8), time_unit="us")
+        with self.assertRaisesRegex(ValueError, "at least 1"):
+            eventcv.open(str(path), max_events=0, sensor_size=(8, 8), time_unit="us")
+
+    def test_offset_shifts_duration_framing(self):
+        # Events at t = 0, 10, 20, 30, 40 us; dt = 10 us. offset is an absolute timestamp in
+        # ms: 0.02 ms = 20 us moves the origin to t = 20, so the first two events fall outside
+        # every frame.
+        path = Path(tempfile.mkdtemp()) / "events.txt"
+        path.write_text("0 0 0 1\n10 1 1 0\n20 2 2 1\n30 3 3 0\n40 4 4 1\n")
+        reader = eventcv.open(
+            str(path), dt_ms=0.01, offset=0.02, sensor_size=(8, 8), time_unit="us"
+        )
+
+        self.assertAlmostEqual(reader.offset, 0.02)
+        self.assertEqual(reader.n_slices, 3)  # frames at [20,30), [30,40), [40,50) us
+        self.assertEqual(len(reader), 3)
+        np.testing.assert_array_equal(reader.slice(0).numpy()[:, 2], [20])
+        np.testing.assert_array_equal(reader.slice(-1).numpy()[:, 2], [40])
+        # windows() also starts at the offset origin.
+        self.assertEqual([w.numpy()[0, 2] for w in reader.windows()], [20, 30, 40])
+
+    def test_offset_shifts_count_framing(self):
+        # offset = 0.02 ms (absolute t = 20 us) skips the first two events, then max_events
+        # counts from there.
+        path = Path(tempfile.mkdtemp()) / "events.txt"
+        path.write_text("0 0 0 1\n10 1 1 0\n20 2 2 1\n30 3 3 0\n40 4 4 1\n")
+        reader = eventcv.open(
+            str(path), max_events=2, offset=0.02, sensor_size=(8, 8), time_unit="us"
+        )
+
+        self.assertAlmostEqual(reader.offset, 0.02)
+        self.assertEqual(reader.n_slices, 2)  # ceil(3 / 2) over the events at/after t=20
+        np.testing.assert_array_equal(reader.slice(0).numpy()[:, 2], [20, 30])
+        np.testing.assert_array_equal(reader.slice(1).numpy()[:, 2], [40])
+        self.assertEqual([len(w) for w in reader.windows()], [2, 1])
+
+    def test_offset_clamps_to_t_min_and_past_end(self):
+        # offset uses the same absolute time base as slice(t0_ms=…). Events at t = 100, 110,
+        # 120 us (t_min = 0.1 ms): an offset before t_min is a no-op (clamped to t_min), one
+        # past the end yields zero frames.
+        path = Path(tempfile.mkdtemp()) / "events.txt"
+        path.write_text("100 0 0 1\n110 1 1 0\n120 2 2 1\n")
+        clamped = eventcv.open(
+            str(path), dt_ms=0.01, offset=0.05, sensor_size=(8, 8), time_unit="us"
+        )
+        self.assertEqual(clamped.n_slices, 3)  # 0.05 ms = 50 us < t_min -> whole recording
+        past_end = eventcv.open(
+            str(path), dt_ms=0.01, offset=1.0, sensor_size=(8, 8), time_unit="us"
+        )
+        self.assertEqual(past_end.n_slices, 0)  # 1 ms = 1000 us > t_max = 120 us
+
+    def test_open_rejects_negative_offset(self):
+        path = Path(tempfile.mkdtemp()) / "events.txt"
+        path.write_text("0 0 0 1\n")
+        with self.assertRaisesRegex(ValueError, "offset"):
+            eventcv.open(str(path), dt_ms=1.0, offset=-1, sensor_size=(8, 8), time_unit="us")
 
     def test_collate_batches_raw_streams_as_a_list(self):
         # A repr-less reader yields EventStreams; ecv.collate returns them as a plain list

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -33,6 +33,68 @@ class LoadTests(unittest.TestCase):
         events[0] = 0
         np.testing.assert_array_equal(stream.numpy()[0], first_event)
 
+    def test_offset_skips_events_before_absolute_time(self):
+        stream = eventcv.load(str(EXAMPLE_PATH))
+        t = stream.numpy()[:, 2]
+        cutoff_us = int(t.min()) + 10_000  # an absolute timestamp 10 ms after t_min
+
+        skipped = eventcv.load(str(EXAMPLE_PATH), offset=cutoff_us / 1000)  # offset is ms
+
+        expected = int((t >= cutoff_us).sum())
+        self.assertEqual(len(skipped), expected)
+        self.assertGreaterEqual(int(skipped.numpy()[:, 2].min()), cutoff_us)
+
+    def test_offset_composes_with_max_events(self):
+        stream = eventcv.load(str(EXAMPLE_PATH))
+        t = stream.numpy()[:, 2]
+        cutoff_us = int(t.min()) + 10_000
+
+        window = eventcv.load(str(EXAMPLE_PATH), offset=cutoff_us / 1000, max_events=100)
+
+        self.assertEqual(len(window), 100)  # capped after the offset
+        # The first kept event is the first at/after the cutoff, not the file's first.
+        self.assertEqual(int(window.numpy()[0, 2]), int(t[t >= cutoff_us].min()))
+
+    def test_offset_rejects_negative(self):
+        with self.assertRaisesRegex(ValueError, "offset"):
+            eventcv.load(str(EXAMPLE_PATH), offset=-1)
+
+    def test_from_numpy_round_trips_a_stream(self):
+        stream = eventcv.load(str(EXAMPLE_PATH))
+
+        rebuilt = eventcv.from_numpy(
+            stream.numpy(), sensor_size=(640, 480), time_unit="us"
+        )
+
+        self.assertIsInstance(rebuilt, eventcv.EventStream)
+        self.assertEqual(rebuilt.sensor_size, (640, 480))
+        np.testing.assert_array_equal(rebuilt.numpy(), stream.numpy())
+
+    def test_from_numpy_infers_sensor_size_and_accepts_txyp(self):
+        events = np.array([[100, 3, 1, 1], [250, 0, 2, -1]])  # t x y p
+
+        stream = eventcv.from_numpy(events, order="txyp", time_unit="us")
+
+        self.assertEqual(stream.sensor_size, (4, 3))
+        np.testing.assert_array_equal(
+            stream.numpy(), [[3, 1, 100, 1], [0, 2, 250, 0]]
+        )
+
+    def test_from_numpy_converts_float_seconds(self):
+        events = np.array([[0.0, 0.0, 0.5, 1.0], [1.0, 1.0, 1.5, 0.0]])  # x y t p
+
+        stream = eventcv.from_numpy(events)  # fractional t -> seconds
+
+        np.testing.assert_array_equal(stream.numpy()[:, 2], [500_000, 1_500_000])
+
+    def test_from_numpy_rejects_bad_input(self):
+        with self.assertRaisesRegex(ValueError, "4"):
+            eventcv.from_numpy(np.zeros((2, 3)))
+        with self.assertRaisesRegex(ValueError, "coordinate"):
+            eventcv.from_numpy(np.array([[-1, 0, 100, 1]]), time_unit="us")
+        with self.assertRaisesRegex(TypeError, "numpy array"):
+            eventcv.from_numpy([[0, 0, 100, 1]])
+
     def test_generates_polarity_representation(self):
         stream = eventcv.load(str(EXAMPLE_PATH))
 
@@ -121,8 +183,8 @@ class LoadTests(unittest.TestCase):
     def test_generates_count_and_averaged_time_surface(self):
         stream = eventcv.load(str(EXAMPLE_PATH))
 
-        count = stream.count(normalize=False)
-        count_norm = stream.count()
+        count = stream.count()
+        count_norm = stream.count(normalize=True)
         atsurf = stream.atsurf()
 
         self.assertEqual((count.kind, count.shape), ("count", (1, 480, 640)))


### PR DESCRIPTION
Part of v1.0.1 issues/features tracking and development:

- when a repr is defined during open() now uses that representation view() correctly
- a from_numpy() function created to turn np.arrays into eventcv objects
- numpy pinning <2 caused build issues in conda-forge for python 3.14, removed the pin
- `offset` can now be parsed into open() to skip to a timestamp value
- aarch64 already included in pyproject/pypi build, fixed in eventcv-feedstock
- normalize=False now the default for uint64 polarity representations/event counts
-  docs updated to reflect new functions and bug fixes

#1 