### PR TITLE
Fix hot pixel filtering on large file streams (#4)

### DIFF
--- a/crates/eventcv-core/src/filter.rs
+++ b/crates/eventcv-core/src/filter.rs
@@ -66,17 +66,48 @@ impl EventStream {
     /// `mean + n_std·std`, with the mean and standard deviation taken over the **active** pixels
     /// (those with at least one event). A uniform or empty stream removes nothing.
     pub fn hot_pixel_filter(&self, n_std: f64) -> EventStream {
+        self.drop_masked_pixels(&self.hot_pixel_mask(n_std))
+    }
+
+    /// The hot-pixel mask this stream would remove: `true` at each pixel whose total event count
+    /// exceeds `mean + n_std·std` (statistics over the **active** pixels), row-major `width·height`.
+    /// Degenerate sensors give an empty mask. Exposed on its own so a reader can compute the mask
+    /// **once** over a whole recording and apply it to every slice with [`Self::drop_masked_pixels`]
+    /// — a per-slice `hot_pixel_filter` instead re-thresholds each window, so hot pixels survive at
+    /// long accumulation times.
+    pub fn hot_pixel_mask(&self, n_std: f64) -> Vec<bool> {
         let (width, height) = self.sensor_size();
         if width == 0 || height == 0 {
-            return self.clone();
+            return Vec::new();
         }
         let mut counts = vec![0u64; width * height];
+        self.add_pixel_counts(&mut counts);
+        Self::hot_pixel_mask_from_counts(&counts, n_std)
+    }
+
+    /// Adds this stream's per-pixel event counts into `counts` (row-major `width·height` for this
+    /// stream's sensor); a mismatched buffer is left untouched. Lets a reader tally a whole
+    /// recording chunk-by-chunk — feeding [`Self::hot_pixel_mask_from_counts`] — without ever
+    /// materialising the full file, so the pre-scan stays within bounded memory.
+    pub fn add_pixel_counts(&self, counts: &mut [u64]) {
+        let (width, height) = self.sensor_size();
+        if counts.len() != width * height {
+            return;
+        }
         let (xs, ys) = (self.xs(), self.ys());
         for index in 0..self.len() {
             counts[ys[index] as usize * width + xs[index] as usize] += 1;
         }
+    }
 
+    /// The hot-pixel mask for pre-tallied per-pixel `counts`: `true` where a count exceeds
+    /// `mean + n_std·std` taken over the **active** (non-zero) pixels. All-zero counts flag nothing.
+    /// The chunked-scan counterpart of [`Self::hot_pixel_mask`].
+    pub fn hot_pixel_mask_from_counts(counts: &[u64], n_std: f64) -> Vec<bool> {
         let active: Vec<u64> = counts.iter().copied().filter(|&c| c > 0).collect();
+        if active.is_empty() {
+            return vec![false; counts.len()]; // no events -> nothing is hot
+        }
         let n = active.len() as f64;
         let mean = active.iter().sum::<u64>() as f64 / n;
         let variance = active
@@ -86,8 +117,20 @@ impl EventStream {
             / n;
         let threshold = mean + n_std * variance.sqrt();
 
+        counts.iter().map(|&c| c as f64 > threshold).collect()
+    }
+
+    /// Drops every event whose pixel is flagged `true` in `mask` (row-major `width·height`, as
+    /// [`Self::hot_pixel_mask`] returns), keeping `(x, y, p, t)` and order. A mask that does not
+    /// match the sensor grid (e.g. the empty mask of a degenerate sensor) removes nothing, so a
+    /// reader can carry one whole-recording mask and apply it to every slice unconditionally.
+    pub fn drop_masked_pixels(&self, mask: &[bool]) -> EventStream {
+        let (width, height) = self.sensor_size();
+        if width == 0 || height == 0 || mask.len() != width * height {
+            return self.clone();
+        }
         self.remap(width, height, |x, y, t, p| {
-            ((counts[y as usize * width + x as usize] as f64) <= threshold).then_some((x, y, t, p))
+            (!mask[y as usize * width + x as usize]).then_some((x, y, t, p))
         })
     }
 }
@@ -172,6 +215,25 @@ mod tests {
             .zip(filtered.ys())
             .all(|(&x, &y)| (x, y) != (1, 1)));
         assert_eq!(filtered.len(), 20); // only the baseline survives
+    }
+
+    #[test]
+    fn hot_pixel_mask_drops_the_pixel_from_a_window_where_it_would_survive() {
+        // Global view: (1,1) is hot. Its mask must still remove (1,1) from a short window where
+        // it fires just once — the window a per-slice hot_pixel_filter would leave untouched.
+        let mut events: Vec<(u16, u16, i64, bool)> =
+            (0..30).map(|t| (1, 1, t as i64, true)).collect();
+        for k in 0..20u16 {
+            events.push((10 + k % 5, 5 + k / 5, 1_000 + i64::from(k), false));
+        }
+        let mask = build(32, 32, &events).hot_pixel_mask(3.0);
+        assert!(mask[33]); // (x=1, y=1) on a 32-wide grid is flagged
+
+        let window = build(32, 32, &[(1, 1, 0, true), (10, 5, 1, false)]);
+        assert_eq!(window.hot_pixel_filter(3.0).len(), 2); // per-window: nothing stands out
+        let filtered = window.drop_masked_pixels(&mask); // global mask: (1,1) still goes
+        assert_eq!(filtered.len(), 1);
+        assert_eq!((filtered.xs()[0], filtered.ys()[0]), (10, 5));
     }
 
     #[test]

--- a/crates/eventcv-core/src/io.rs
+++ b/crates/eventcv-core/src/io.rs
@@ -203,6 +203,24 @@ pub trait SliceSource: Send {
     fn slice_index(&self, i0: usize, i1: usize) -> Result<EventStream, IoError>;
     /// Events whose timestamp (µs) lies in the half-open window `[t0, t1)`.
     fn slice_time(&self, t0: i64, t1: i64) -> Result<EventStream, IoError>;
+
+    /// Per-pixel event counts over the whole file (row-major `width·height`), out-of-bounds
+    /// events dropped — what the reader's hot-pixel pre-scan needs. The default tallies through
+    /// `slice_index` in bounded chunks; a source that can read coordinates alone (HDF5) overrides
+    /// this to skip the `t`/`p` columns and stream construction, which is most of the work.
+    fn pixel_counts(&self) -> Result<Vec<u64>, IoError> {
+        const CHUNK: usize = 8_000_000;
+        let (width, height) = self.sensor_size();
+        let mut counts = vec![0u64; width * height];
+        let total = self.n_events();
+        let mut start = 0;
+        while start < total {
+            let end = (start + CHUNK).min(total);
+            self.slice_index(start, end)?.add_pixel_counts(&mut counts);
+            start = end;
+        }
+        Ok(counts)
+    }
 }
 
 /// A [`SliceSource`] backed by an already-loaded stream — the universal fallback for
@@ -263,6 +281,14 @@ impl SliceSource for MemorySliceSource {
     fn slice_time(&self, t0: i64, t1: i64) -> Result<EventStream, IoError> {
         let ts = self.stream.ts();
         Ok(self.rebuild((0..ts.len()).filter(|&index| ts[index] >= t0 && ts[index] < t1)))
+    }
+
+    fn pixel_counts(&self) -> Result<Vec<u64>, IoError> {
+        // Already resident — tally straight from the stream, no chunked rebuilds.
+        let (width, height) = self.stream.sensor_size();
+        let mut counts = vec![0u64; width * height];
+        self.stream.add_pixel_counts(&mut counts);
+        Ok(counts)
     }
 }
 

--- a/crates/eventcv-core/src/io/h5.rs
+++ b/crates/eventcv-core/src/io/h5.rs
@@ -342,6 +342,93 @@ impl SliceSource for Hdf5SliceSource {
         let start = self.lower_bound_time(t0)?;
         self.read_window(start, t1)
     }
+
+    /// Tallies per-pixel counts reading only the `x`/`y` columns — skipping the `t` column (by
+    /// far the largest on disk) and `p`, plus timestamp conversion and stream construction, which
+    /// are the bulk of a slice's cost. Above [`SCAN_BUDGET`] events it further reads only
+    /// evenly-spaced segments rather than every event: the hot-pixel mask is an outlier test, and
+    /// stuck pixels fire throughout the recording, so they dominate any representative sample while
+    /// the threshold (`mean + n·std`) stays ~scale-invariant. This keeps a multi-GB scan bounded.
+    fn pixel_counts(&self) -> Result<Vec<u64>, IoError> {
+        let [x, y, ..] = &self.datasets;
+        let mut counts = vec![0u64; self.width * self.height];
+        if self.total <= SCAN_BUDGET {
+            let mut start = 0;
+            while start < self.total {
+                let end = (start + BLOCK).min(self.total);
+                add_xy_counts(x, y, start..end, self.width, self.height, &mut counts)?;
+                start = end;
+            }
+        } else {
+            // Read SCAN_SEGMENT-event windows spread evenly across the file (~SCAN_BUDGET total).
+            let segments = SCAN_BUDGET / SCAN_SEGMENT;
+            let stride = self.total / segments;
+            for i in 0..segments {
+                let start = i * stride;
+                let end = (start + SCAN_SEGMENT).min(self.total);
+                add_xy_counts(x, y, start..end, self.width, self.height, &mut counts)?;
+            }
+        }
+        Ok(counts)
+    }
+}
+
+/// Target events for the hot-pixel pre-scan. A recording larger than this is *sampled* as
+/// [`SCAN_SEGMENT`]-event windows spread evenly across it rather than read in full — enough to
+/// pin the count distribution's shape (all a stuck-pixel outlier test needs) while keeping the
+/// scan of a multi-GB file well under a second.
+const SCAN_BUDGET: usize = 32_000_000;
+/// Events per evenly-spaced sample window. Kept small (≈ one on-disk chunk) so the budget buys
+/// *many* windows: fine temporal coverage is what catches a hot pixel whose bursts of activity
+/// would fall between coarser, wider-spaced samples.
+const SCAN_SEGMENT: usize = 100_000;
+
+/// Adds the `x`/`y` columns over `range` into `counts`, dropping out-of-bounds events (matching
+/// [`read_range`]). Reads coordinates in their native small-int type — no widening to `i64`.
+fn add_xy_counts(
+    x: &Dataset,
+    y: &Dataset,
+    range: Range<usize>,
+    width: usize,
+    height: usize,
+    counts: &mut [u64],
+) -> Result<(), IoError> {
+    let xs = read_coords(x, range.clone())?;
+    let ys = read_coords(y, range)?;
+    for (&xi, &yi) in xs.iter().zip(&ys) {
+        if xi < width && yi < height {
+            counts[yi * width + xi] += 1;
+        }
+    }
+    Ok(())
+}
+
+/// Reads a coordinate column over `range` as `usize`, dispatching on its on-disk width like
+/// [`column_max`] so a `u16` file is not widened through `i64`.
+fn read_coords(dataset: &Dataset, range: Range<usize>) -> Result<Vec<usize>, IoError> {
+    let descriptor = dataset
+        .dtype()
+        .and_then(|dtype| dtype.to_descriptor())
+        .map_err(map_hdf5_error)?;
+    Ok(match descriptor {
+        TypeDescriptor::Unsigned(IntSize::U1) => read_block::<u8>(dataset, range)?
+            .iter()
+            .map(|&v| usize::from(v))
+            .collect(),
+        TypeDescriptor::Unsigned(IntSize::U2) => read_block::<u16>(dataset, range)?
+            .iter()
+            .map(|&v| usize::from(v))
+            .collect(),
+        TypeDescriptor::Unsigned(IntSize::U4) => read_block::<u32>(dataset, range)?
+            .iter()
+            .map(|&v| v as usize)
+            .collect(),
+        // Wider or signed columns: reuse the general reader, clamping negatives out of bounds.
+        _ => read_integers(dataset, range)?
+            .iter()
+            .map(|&v| if v < 0 { usize::MAX } else { v as usize })
+            .collect(),
+    })
 }
 
 /// Cheaply confirms the timestamp column is non-decreasing by sampling, so in-place
@@ -919,6 +1006,45 @@ mod tests {
         assert_eq!(source.slice_index(4, 100).unwrap().ts(), &[5000, 6000]); // hi clamped
         assert!(source.slice_index(10, 20).unwrap().is_empty()); // wholly past the end
         std::fs::remove_dir_all(path.parent().unwrap()).ok();
+    }
+
+    #[test]
+    fn pixel_counts_reads_xy_only_and_drops_out_of_bounds() {
+        // The hot-pixel pre-scan tallies coordinates without the t/p columns; it must still drop
+        // out-of-bounds events exactly as read_range does. Small file -> the exact (non-sampled)
+        // branch. Events: (1,2), (3,0), (0,1), and (4,0) which is out of a 4x4 sensor.
+        let dir = temp_dir("h5counts");
+        let path = dir.join("events.h5");
+        {
+            let file = File::create(&path).unwrap();
+            let group = file.create_group("events").unwrap();
+            for (name, data) in [("x", vec![1u16, 3, 0, 4]), ("y", vec![2u16, 0, 1, 0])] {
+                group
+                    .new_dataset_builder()
+                    .with_data(&data[..])
+                    .create(name)
+                    .unwrap();
+            }
+            group
+                .new_dataset_builder()
+                .with_data(&[1000u64, 2000, 3000, 4000][..])
+                .create("t")
+                .unwrap();
+            group
+                .new_dataset_builder()
+                .with_data(&[true, false, true, false][..])
+                .create("p")
+                .unwrap();
+        }
+        let source = open_hdf5_slice(&path, &options(4, 4, TimeUnit::Microseconds)).unwrap();
+
+        let counts = source.pixel_counts().unwrap();
+        assert_eq!(counts.len(), 16);
+        assert_eq!(counts.iter().sum::<u64>(), 3); // (4, 0) dropped: x == width
+        assert_eq!(counts[9], 1); // (x=1, y=2) -> 2*4 + 1
+        assert_eq!(counts[3], 1); // (x=3, y=0)
+        assert_eq!(counts[4], 1); // (x=0, y=1) -> 1*4 + 0
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]

--- a/crates/eventcv-py/src/lib.rs
+++ b/crates/eventcv-py/src/lib.rs
@@ -772,7 +772,7 @@ fn parse_dt_ms(dt_ms: Option<f64>) -> PyResult<Option<i64>> {
 }
 
 #[pyfunction]
-#[pyo3(signature = (path, *, dt_ms=None, max_events=None, offset=None, repr=None, sensor_size=None, time_unit=None, order="txyp", topic=None))]
+#[pyo3(signature = (path, *, dt_ms=None, max_events=None, offset=None, repr=None, sensor_size=None, time_unit=None, order="txyp", topic=None, hot_pixel_filter=false, hot_pixel_std=3.0))]
 #[allow(clippy::too_many_arguments)]
 fn open(
     py: Python<'_>,
@@ -785,6 +785,8 @@ fn open(
     time_unit: Option<&str>,
     order: &str,
     topic: Option<String>,
+    hot_pixel_filter: bool,
+    hot_pixel_std: f64,
 ) -> PyResult<PyEventReader> {
     let mode = match (parse_dt_ms(dt_ms)?, max_events) {
         (Some(_), Some(_)) => {
@@ -831,6 +833,19 @@ fn open(
         }
         _ => 0,
     };
+    // Whole-recording hot-pixel mask: tally per-pixel counts once now (the accepted pre-processing
+    // cost) so every slice drops the same stuck pixels. A per-slice filter can't — its threshold
+    // shifts with each window, letting hot pixels survive at long dt_ms. `pixel_counts` reads only
+    // the coordinate columns (HDF5), so the scan stays lazy and cheap. `None` unless requested.
+    let hot_pixel_mask = if hot_pixel_filter {
+        let counts = reader.pixel_counts().map_err(map_io_error)?;
+        Some(Arc::from(EventStream::hot_pixel_mask_from_counts(
+            &counts,
+            hot_pixel_std,
+        )))
+    } else {
+        None
+    };
     Ok(PyEventReader {
         inner: Arc::new(Mutex::new(reader)),
         mode,
@@ -838,6 +853,7 @@ fn open(
         slice_op: None,
         offset_us,
         base_index,
+        hot_pixel_mask,
     })
 }
 
@@ -864,6 +880,11 @@ struct PyEventReader {
     /// The event index of the first event at/after the offset origin — the fixed-count framing
     /// counterpart of `offset_us` (0 for duration mode, no offset, or an offset past the end).
     base_index: usize,
+    /// Whole-recording hot-pixel mask from `open(hot_pixel_filter=True)` (row-major
+    /// `width·height`, `true` = drop). Computed once at `open` and applied to every fetched slice
+    /// before any per-slice op, so stuck pixels are removed consistently across frames; `None`
+    /// when hot-pixel filtering was not requested.
+    hot_pixel_mask: Option<Arc<[bool]>>,
 }
 
 /// A per-slice `EventStream` → `EventStream` operation a reader carries (Phase 5 corner
@@ -906,12 +927,14 @@ enum SliceWindow {
     Index(usize, usize),
 }
 
-/// Reads `window` from the shared reader off-GIL, applying the per-slice op.
+/// Reads `window` from the shared reader off-GIL, dropping the whole-recording hot pixels (if
+/// any) before the per-slice op, so corner detectors never fire on stuck pixels.
 fn fetch_window(
     py: Python<'_>,
     reader: &Arc<Mutex<Reader>>,
     window: SliceWindow,
     op: Option<SliceOp>,
+    hot_pixel_mask: Option<Arc<[bool]>>,
 ) -> PyResult<EventStream> {
     let reader = Arc::clone(reader);
     py.detach(move || {
@@ -920,7 +943,13 @@ fn fetch_window(
             SliceWindow::Time(t0, t1) => guard.slice_time(t0, t1),
             SliceWindow::Index(i0, i1) => guard.slice_index(i0, i1),
         }
-        .map(|stream| apply_slice_op(op, stream))
+        .map(|stream| {
+            let stream = match &hot_pixel_mask {
+                Some(mask) => stream.drop_masked_pixels(mask),
+                None => stream,
+            };
+            apply_slice_op(op, stream)
+        })
     })
     .map_err(map_io_error)
 }
@@ -1077,6 +1106,7 @@ impl PyEventReader {
             slice_op: self.slice_op,
             offset_us: self.offset_us,
             base_index: self.base_index,
+            hot_pixel_mask: self.hot_pixel_mask.clone(),
         })
     }
 
@@ -1110,7 +1140,13 @@ impl PyEventReader {
         let mut frames = Vec::with_capacity(indices.len());
         for index in indices {
             let window = self.window_for_index(index)?;
-            let stream = fetch_window(py, &self.inner, window, self.slice_op)?;
+            let stream = fetch_window(
+                py,
+                &self.inner,
+                window,
+                self.slice_op,
+                self.hot_pixel_mask.clone(),
+            )?;
             let frame = py
                 .detach(|| spec.generate(&stream))
                 .map_err(map_representation_error)?;
@@ -1194,10 +1230,12 @@ impl PyEventReader {
     /// Reads `window` off-GIL into an `EventStream` carrying the reader's stored repr,
     /// applying the per-slice op (e.g. `efast`) if one is set.
     fn fetch(&self, py: Python<'_>, window: SliceWindow) -> PyResult<PyEventStream> {
-        fetch_window(py, &self.inner, window, self.slice_op).map(|inner| PyEventStream {
-            inner,
-            repr: self.repr,
-        })
+        fetch_window(py, &self.inner, window, self.slice_op, self.hot_pixel_mask.clone()).map(
+            |inner| PyEventStream {
+                inner,
+                repr: self.repr,
+            },
+        )
     }
 
     /// A new reader over the same file (and mode/`repr`) that applies `op` to every slice.
@@ -1209,6 +1247,7 @@ impl PyEventReader {
             slice_op: Some(op),
             offset_us: self.offset_us,
             base_index: self.base_index,
+            hot_pixel_mask: self.hot_pixel_mask.clone(),
         }
     }
 
@@ -1219,6 +1258,7 @@ impl PyEventReader {
             cursor,
             slice_op: self.slice_op,
             repr: self.repr,
+            hot_pixel_mask: self.hot_pixel_mask.clone(),
         }
     }
 
@@ -1293,6 +1333,8 @@ struct PyWindowIterator {
     /// The reader's stored representation, carried onto each yielded window (so `open(repr=…)`
     /// survives `for w in reader.windows(): w.view()`).
     repr: Option<ReprSpec>,
+    /// The reader's whole-recording hot-pixel mask, applied to each yielded window.
+    hot_pixel_mask: Option<Arc<[bool]>>,
 }
 
 /// Walks a recording as consecutive time windows (`windows(step_ms=…)` / `dt_ms`
@@ -1350,7 +1392,13 @@ impl PyWindowIterator {
         let Some(window) = self.cursor.advance() else {
             return Ok(None);
         };
-        let stream = fetch_window(py, &self.reader, window, self.slice_op)?;
+        let stream = fetch_window(
+            py,
+            &self.reader,
+            window,
+            self.slice_op,
+            self.hot_pixel_mask.clone(),
+        )?;
         Ok(Some(PyEventStream {
             inner: stream,
             repr: self.repr,

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -83,6 +83,16 @@ begin at that time, and earlier events fall outside every frame. It composes wit
 reader = ecv.open("huge.hdf5", dt_ms=30, offset=1_000)   # frame 0 starts at t = 1 s
 ```
 
+Pass `hot_pixel_filter=True` to strip stuck pixels **consistently across the whole recording**:
+`open` scans the file once up front and drops those pixels from every slice. Unlike
+`stream.hot_pixel_filter()` run per slice — whose threshold shifts window to window, so hot
+pixels leak back at long `dt_ms` — this is a single global mask. `hot_pixel_std` (default `3.0`)
+tunes it:
+
+```python
+reader = ecv.open("huge.hdf5", dt_ms=1000, hot_pixel_filter=True)   # hot pixels gone everywhere
+```
+
 For a recording whose timestamps are epoch-based, `offset` is just that epoch time in ms
 (e.g. `offset=1_587_540_271_650`). Values before the recording clamp to the start; values
 past the end give zero frames.

--- a/docs/tutorials/03-streaming-large-files.ipynb
+++ b/docs/tutorials/03-streaming-large-files.ipynb
@@ -168,6 +168,45 @@
   },
   {
    "cell_type": "markdown",
+   "id": "hotpix01",
+   "metadata": {},
+   "source": [
+    "## Remove hot pixels across the recording\n",
+    "\n",
+    "Stuck (\"hot\") pixels fire far more than the scene warrants and speckle every frame. Pass `hot_pixel_filter=True` and `open` flags them **once, globally** — it scans the recording up front and drops those pixels from *every* slice it returns, so the cleanup is identical across the whole file.\n",
+    "\n",
+    "This has to be global: running `stream.hot_pixel_filter()` on each slice re-computes its threshold per window, so at long `dt_ms` a genuinely hot pixel stops standing out from the busy scene and survives. The pre-scan stays lightweight — it reads only the event coordinates (not timestamps/polarity) and, on a large file, samples windows spread across it rather than every event — so the overhead is small even on multi-gigabyte recordings. `hot_pixel_std` (default `3.0`) sets how aggressive the cut is."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "hotpix02",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "106295 events -> 96323 after hot-pixel removal (9972 dropped)\n",
+      "frame 0: 54231 -> 50251 events\n"
+     ]
+    }
+   ],
+   "source": [
+    "plain    = ecv.open(PATH, dt_ms=20)\n",
+    "filtered = ecv.open(PATH, dt_ms=20, hot_pixel_filter=True)\n",
+    "\n",
+    "before = sum(len(w) for w in plain.windows())\n",
+    "after  = sum(len(w) for w in filtered.windows())\n",
+    "print(f\"{before} events -> {after} after hot-pixel removal ({before - after} dropped)\")\n",
+    "\n",
+    "# One global mask cleans every slice, so hot pixels never reappear window to window:\n",
+    "print(\"frame 0:\", len(plain.slice(0)), \"->\", len(filtered.slice(0)), \"events\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "a0a4aa01",
    "metadata": {},
    "source": [
@@ -179,6 +218,10 @@
     "reader = ecv.open(\"brisbane_707M.hdf5\", dt_ms=30)  # opens instantly — nothing read yet\n",
     "reader.n_slices                                     # frame count from the timestamp range\n",
     "frame = reader.slice(5000)                          # ~32 ms: one binary search + read\n",
+    "\n",
+    "# Strip stuck pixels across the whole recording; the only up-front read is a light,\n",
+    "# coordinates-only sampled pre-scan, so it stays cheap even at this scale.\n",
+    "clean = ecv.open(\"brisbane_707M.hdf5\", dt_ms=30, hot_pixel_filter=True)\n",
     "```\n",
     "\n",
     "Only the events in the requested window are decoded, so memory stays flat regardless of file size. To build a training loop or render a video, combine `windows()` with a representation and `export_png` — see the [transforms tutorial](02-transforms-and-representations.ipynb) and the [`open` reference](../api.md)."

--- a/python/eventcv/load.py
+++ b/python/eventcv/load.py
@@ -97,6 +97,8 @@ def open(
     time_unit: str | None = None,
     order: str = "txyp",
     topic: str | None = None,
+    hot_pixel_filter: bool = False,
+    hot_pixel_std: float = 3.0,
 ) -> EventReader:
     """Open a file for lazy slicing without loading it whole.
 
@@ -128,6 +130,17 @@ def open(
     ``sensor_size`` and ``time_unit`` are **auto-detected** when omitted (see
     :func:`load`); ``order``/``topic`` match :func:`load`. For a multi-GB HDF5, pass
     ``sensor_size`` to skip the one-time coordinate scan resolution inference needs.
+
+    Pass ``hot_pixel_filter=True`` to strip *stuck* pixels consistently across the whole
+    recording. ``open`` scans the file once up front, flags every pixel whose event count exceeds
+    ``mean + hot_pixel_std·std`` (over the active pixels), and drops those pixels from every slice
+    it returns — the filter runs before any per-slice op (``efast`` / ``repr`` / …). This is
+    deliberately **global**: calling :meth:`EventStream.hot_pixel_filter` per slice re-thresholds
+    each window, so genuinely hot pixels survive at long ``dt_ms``. The pre-scan is kept
+    lightweight — it reads only the event coordinates (skipping the timestamp/polarity columns)
+    and, for a large recording, samples windows spread evenly across it rather than every event, so
+    the mask is a robust estimate rather than an exact tally. ``hot_pixel_std`` (default ``3.0``)
+    tunes how aggressive it is, matching :meth:`EventStream.hot_pixel_filter`.
 
     Pass ``repr`` (a representation name — ``"count"``, ``"voxel"``, ``"tsurf"``, ``"flow"``
     for optical flow, …) to make the reader a PyTorch-style **map dataset**:
@@ -176,6 +189,8 @@ def open(
         time_unit=time_unit,
         order=order,
         topic=topic,
+        hot_pixel_filter=hot_pixel_filter,
+        hot_pixel_std=hot_pixel_std,
     )
 
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -287,6 +287,56 @@ class OpenReaderTests(unittest.TestCase):
             self._frames().slice(0, t1_ms=5.0)
 
 
+class HotPixelReaderTests(unittest.TestCase):
+    """`open(hot_pixel_filter=True)` strips stuck pixels globally, across every slice."""
+
+    def _recording(self):
+        """8x8 `t x y p` file where (1,1) is stuck (fires every us) over single-event pixels.
+
+        (1,1)'s global count (50) dwarfs the 20 baseline pixels (1 each), so it exceeds
+        mean + 3*std; the events span 0..49 us -> five 10 us (dt_ms=0.01) frames."""
+        events = [(t, 1, 1, 1) for t in range(50)]  # stuck pixel, one event per microsecond
+        events += [(k, 2 + k % 6, 2 + k // 6, 0) for k in range(20)]  # sparse baseline
+        events.sort()  # in-place text slicing needs time-ordered events
+        rows = [f"{t} {x} {y} {p}" for (t, x, y, p) in events]
+        path = Path(tempfile.mkdtemp()) / "hot.txt"
+        path.write_text("\n".join(rows) + "\n")
+        return str(path)
+
+    def _has_hot_pixel(self, stream):
+        xy = stream.numpy()[:, :2]
+        return bool((xy == [1, 1]).all(axis=1).any())
+
+    def test_off_by_default(self):
+        reader = eventcv.open(self._recording(), sensor_size=(8, 8), time_unit="us")
+        self.assertTrue(self._has_hot_pixel(reader.slice()))  # (1,1) present, unfiltered
+
+    def test_removes_pixel_from_every_slice(self):
+        reader = eventcv.open(
+            self._recording(), dt_ms=0.01, sensor_size=(8, 8), time_unit="us", hot_pixel_filter=True
+        )
+        for n in range(reader.n_slices):
+            self.assertFalse(self._has_hot_pixel(reader.slice(n)), f"survived in slice {n}")
+        # Only the 50 stuck events go; the 20 baseline events remain, via both slice and windows.
+        self.assertEqual(sum(len(reader.slice(n)) for n in range(reader.n_slices)), 20)
+        self.assertEqual(sum(len(w) for w in reader.windows()), 20)
+
+    def test_composes_with_repr(self):
+        reader = eventcv.open(
+            self._recording(), dt_ms=0.01, sensor_size=(8, 8), time_unit="us",
+            hot_pixel_filter=True, repr="count",
+        )
+        self.assertEqual(sum(int(reader[n][:, 1, 1].sum()) for n in range(len(reader))), 0)
+
+    def test_std_controls_aggressiveness(self):
+        # A high threshold flags nothing, so even the stuck pixel survives.
+        reader = eventcv.open(
+            self._recording(), sensor_size=(8, 8), time_unit="us",
+            hot_pixel_filter=True, hot_pixel_std=100.0,
+        )
+        self.assertTrue(self._has_hot_pixel(reader.slice()))
+
+
 class DatasetReaderTests(unittest.TestCase):
     """`EventReader` as a PyTorch-style map dataset (Workstream D2)."""
 


### PR DESCRIPTION
## Description
This PR contributes a better automated hot pixel filtering method on an `EventReader` object when using the `ecv.open()` function. The only prior method was to call hot pixel filtering on an `EventFrame` object either loaded as a full stream or sliced. The issue with using hot pixel filtering on slices is the inconsistency in which pixels are filtered out, whereas the caluclation of pixel activity and standard deviation over a whole file is more consistent. 

A neglible overhead is introduced when `open(hot_pixel_filter=True)` and provides cleaner event stream data.

```python
import eventcv as ecv
import time

# sunset2.hdf5 approximately 5GB in size with >700M events

start=time.time()
stream = ecv.open("sunset2.hdf5", dt_ms=1000)
print(f"No hot pixel filtering: {time.time()-start}s")

start=time.time()
stream_filter = ecv.open("sunset2.hdf5", dt_ms=1000, hot_pixel_filter=True)
print(f"With hot pixel filtering: {time.time()-start}s")
```

```console
No hot pixel filtering: 0.16720294952392578s
With hot pixel filtering: 1.2635931968688965s
```

Without filtering:

<img width="355" height="261" alt="Screenshot from 2026-07-09 15-07-05" src="https://github.com/user-attachments/assets/0a1db5ac-e7ef-4e72-b654-f4dea8e136d2" />

With filtering:

<img width="355" height="261" alt="Screenshot from 2026-07-09 15-07-21" src="https://github.com/user-attachments/assets/19387a8d-7915-4527-8b93-70236ba7e7c7" />

Additionally validated in [Event-LAB](https://github.com/EventLAB-Team/Event-LAB) `sparse_event` method yielding identical results to manual/hand-derived hot pixel coordinate removal.

## Related Issue
References issue #4 

## Checklist and questions
- [x] My code follows the style and [contribution guidelines](https://github.com/EventLAB-Team/eventcv/tree/main?tab=contributing-ov-file) of this project
- [ ] If adding a new feature, I have created the relevant `test/` and have verified that it passes
- [x] I have made alterations to pre-existing functions