### PR TITLE
Fix load() with representation behaviour (#6)

### DIFF
--- a/crates/eventcv-py/src/lib.rs
+++ b/crates/eventcv-py/src/lib.rs
@@ -954,6 +954,30 @@ fn fetch_window(
     .map_err(map_io_error)
 }
 
+/// Wraps a freshly fetched slice for a public slice API. When the reader carries a
+/// representation (`open(repr=…)` / `with_repr`) the slice is rendered eagerly and returned as
+/// an `EventFrame` (so `open(repr="mcts").slice(0)` == the frame `open().slice(0).mcts()`
+/// yields); otherwise the raw `EventStream` is returned.
+fn render_slice(
+    py: Python<'_>,
+    repr: Option<ReprSpec>,
+    stream: EventStream,
+) -> PyResult<Py<PyAny>> {
+    match repr {
+        Some(spec) => {
+            let frame = py
+                .detach(|| spec.generate(&stream))
+                .map_err(map_representation_error)?;
+            Ok(Bound::new(py, PyEventFrame { inner: frame })?
+                .into_any()
+                .unbind())
+        }
+        None => Ok(Bound::new(py, PyEventStream { inner: stream, repr: None })?
+            .into_any()
+            .unbind()),
+    }
+}
+
 #[pymethods]
 impl PyEventReader {
     /// `n_slices` in the `dt_ms` / `max_events` frame-dataset modes (so `len(reader) ==
@@ -1026,12 +1050,13 @@ impl PyEventReader {
         self.offset_us.map(us_to_ms)
     }
 
-    /// One slice as an `EventStream`. With a positional index `n` (requires
-    /// `open(dt_ms=…)` or `open(max_events=…)`), returns the `n`-th fixed frame — the
-    /// `dt_ms`-long window `[t_min + n·dt, t_min + (n+1)·dt)`, or the `max_events`-sized
-    /// event chunk `[n·N, (n+1)·N)`; negative `n` counts from the end. Otherwise returns
-    /// the half-open time window `[t0_ms, t1_ms)`, with omitted bounds extending to the
-    /// recording's start / end.
+    /// One slice. With a positional index `n` (requires `open(dt_ms=…)` or
+    /// `open(max_events=…)`), returns the `n`-th fixed frame — the `dt_ms`-long window
+    /// `[t_min + n·dt, t_min + (n+1)·dt)`, or the `max_events`-sized event chunk
+    /// `[n·N, (n+1)·N)`; negative `n` counts from the end. Otherwise returns the half-open
+    /// time window `[t0_ms, t1_ms)`, with omitted bounds extending to the recording's start /
+    /// end. When the reader carries a representation (`open(repr=…)` / `with_repr`) the slice
+    /// is rendered to that `EventFrame`; otherwise it is a raw `EventStream`.
     #[pyo3(signature = (index=None, *, t0_ms=None, t1_ms=None))]
     fn slice(
         &self,
@@ -1039,7 +1064,7 @@ impl PyEventReader {
         index: Option<i64>,
         t0_ms: Option<f64>,
         t1_ms: Option<f64>,
-    ) -> PyResult<PyEventStream> {
+    ) -> PyResult<Py<PyAny>> {
         let window = if let Some(index) = index {
             if t0_ms.is_some() || t1_ms.is_some() {
                 return Err(PyValueError::new_err(
@@ -1054,7 +1079,7 @@ impl PyEventReader {
                 t1_ms.map_or(hi.saturating_add(1), ms_to_us), // +1 keeps the last event
             )
         };
-        self.fetch(py, window)
+        self.fetch_slice(py, window)
     }
 
     /// `reader[n]` — the `n`-th fixed frame (requires `open(dt_ms=…)` or
@@ -1167,14 +1192,16 @@ impl PyEventReader {
         stack_frames(py, &frames, template)
     }
 
-    /// Events whose index lies in `[i0, i1)` (clamped to the file).
+    /// Events whose index lies in `[i0, i1)` (clamped to the file). Rendered to the reader's
+    /// `EventFrame` when a representation is set (`open(repr=…)` / `with_repr`), else a raw
+    /// `EventStream`.
     #[pyo3(signature = (i0, i1))]
-    fn slice_count(&self, py: Python<'_>, i0: i64, i1: i64) -> PyResult<PyEventStream> {
+    fn slice_count(&self, py: Python<'_>, i0: i64, i1: i64) -> PyResult<Py<PyAny>> {
         let i0 =
             usize::try_from(i0).map_err(|_| PyValueError::new_err("i0 must be non-negative"))?;
         let i1 =
             usize::try_from(i1).map_err(|_| PyValueError::new_err("i1 must be non-negative"))?;
-        self.fetch(py, SliceWindow::Index(i0, i1))
+        self.fetch_slice(py, SliceWindow::Index(i0, i1))
     }
 
     /// Lazy iterator of consecutive windows: each is `[start, start + span_ms)` and
@@ -1182,7 +1209,8 @@ impl PyEventReader {
     /// (so `windows()` walks every `slice(n)`), and `span_ms` defaults to `step_ms`
     /// (non-overlapping). For a `max_events` reader, `windows()` without arguments walks
     /// the fixed-count slices instead. Streams a multi-GB file window-by-window without
-    /// loading it.
+    /// loading it. Each item is a rendered `EventFrame` when the reader carries a
+    /// representation (`open(repr=…)` / `with_repr`), else a raw `EventStream`.
     #[pyo3(signature = (*, step_ms=None, span_ms=None))]
     fn windows(&self, step_ms: Option<f64>, span_ms: Option<f64>) -> PyResult<PyWindowIterator> {
         let guard = self.inner.lock().unwrap();
@@ -1236,6 +1264,14 @@ impl PyEventReader {
                 repr: self.repr,
             },
         )
+    }
+
+    /// Reads `window` and wraps it for a public slice API: rendered to the reader's
+    /// `EventFrame` when a representation is set, else the raw `EventStream`.
+    fn fetch_slice(&self, py: Python<'_>, window: SliceWindow) -> PyResult<Py<PyAny>> {
+        let stream =
+            fetch_window(py, &self.inner, window, self.slice_op, self.hot_pixel_mask.clone())?;
+        render_slice(py, self.repr, stream)
     }
 
     /// A new reader over the same file (and mode/`repr`) that applies `op` to every slice.
@@ -1330,8 +1366,8 @@ struct PyWindowIterator {
     reader: Arc<Mutex<Reader>>,
     cursor: WindowCursor,
     slice_op: Option<SliceOp>,
-    /// The reader's stored representation, carried onto each yielded window (so `open(repr=…)`
-    /// survives `for w in reader.windows(): w.view()`).
+    /// The reader's stored representation. When set (`open(repr=…)` / `with_repr`) each yielded
+    /// window is rendered to that `EventFrame`; otherwise a raw `EventStream` is yielded.
     repr: Option<ReprSpec>,
     /// The reader's whole-recording hot-pixel mask, applied to each yielded window.
     hot_pixel_mask: Option<Arc<[bool]>>,
@@ -1388,7 +1424,7 @@ impl PyWindowIterator {
         slf
     }
 
-    fn __next__(&mut self, py: Python<'_>) -> PyResult<Option<PyEventStream>> {
+    fn __next__(&mut self, py: Python<'_>) -> PyResult<Option<Py<PyAny>>> {
         let Some(window) = self.cursor.advance() else {
             return Ok(None);
         };
@@ -1399,10 +1435,7 @@ impl PyWindowIterator {
             self.slice_op,
             self.hot_pixel_mask.clone(),
         )?;
-        Ok(Some(PyEventStream {
-            inner: stream,
-            repr: self.repr,
-        }))
+        render_slice(py, self.repr, stream).map(Some)
     }
 }
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -97,16 +97,21 @@ For a recording whose timestamps are epoch-based, `offset` is just that epoch ti
 (e.g. `offset=1_587_540_271_650`). Values before the recording clamp to the start; values
 past the end give zero frames.
 
-Pass `repr=` to give the reader a **default representation**. It is remembered by every
-slice, so `slice(n).view()` renders it (no need to name it again), and it makes the reader
-a PyTorch map-style dataset where `reader[i]` is the dense `[C, H, W]` array:
+Pass `repr=` to make the reader a **representation source**. Every slice-yielding call —
+`slice`, `slice_count`, and each item from `windows()` — applies it, returning the rendered
+{class}`~eventcv.EventFrame` directly, so `open(path, repr="mcts").slice(0)` is exactly
+`open(path).slice(0).mcts()`. It also makes the reader a PyTorch map-style dataset where
+`reader[i]` is the dense `[C, H, W]` array:
 
 ```python
 import torch
 
 reader = ecv.open("huge.hdf5", dt_ms=30, repr="mcts")
-reader.slice(500).view()               # shows MCTS — the stored repr (not raw polarity)
-reader.slice(500).view("count")        # an explicit name still overrides it
+frame = reader.slice(500)              # an EventFrame — MCTS already applied
+frame.view()                           # render it (no need to name the repr again)
+frame.numpy()                          # the dense [C, H, W] array
+for frame in reader.windows():         # windows() yields rendered frames too
+    ...
 
 # as a PyTorch map-style dataset (dense arrays collate straight into a tensor)
 ds = ecv.open("huge.hdf5", dt_ms=30, repr="count")
@@ -114,9 +119,10 @@ ds = ecv.open("huge.hdf5", dt_ms=30, repr="count")
 loader = torch.utils.data.DataLoader(ds, batch_size=32, shuffle=True)
 ```
 
-Without `repr`, `reader[i]` stays a raw {class}`~eventcv.EventStream`. Those are sparse and
-variable-length, so a `DataLoader` can't stack them — pass {func}`eventcv.collate` to batch
-them as a `list` instead:
+Without `repr`, `slice(n)` and `reader[i]` return raw {class}`~eventcv.EventStream`s, so name
+the representation on the slice yourself: `reader.slice(500).mcts()` (or `.view("count")`).
+Those streams are sparse and variable-length, so a `DataLoader` can't stack them — pass
+{func}`eventcv.collate` to batch them as a `list` instead:
 
 ```python
 import torch

--- a/docs/representations.md
+++ b/docs/representations.md
@@ -54,9 +54,10 @@ ecv.flatten(stream, "polarity", normalize=False)
 
 Two channels, `[positive, negative]`: raw event counts per pixel per polarity (`uint64`), or
 `uint8` rescaled to the busiest pixel when `normalize=True` (the default). This is the frame
-rendered whenever no representation is requested and the stream has no stored `repr` (from
-`open(repr=...)`) — there is no dedicated `.polarity()` method, only the name form and the
-implicit default.
+rendered whenever no representation is requested or stored on the stream — there is no
+dedicated `.polarity()` method, only the name form and the implicit default. (A reader opened
+with `open(repr=...)` renders that representation on `slice()` directly instead of falling back
+to polarity.)
 
 ## Binary
 
@@ -221,7 +222,10 @@ reader = ecv.open("huge.hdf5", dt_ms=30, repr="mcts")    # mcts, default max_win
 # parameters by name — only with_repr forwards them:
 reader = ecv.open("huge.hdf5", dt_ms=30).with_repr("voxel", bins=5)
 array = reader[0]                                        # [5, H, W] voxel for frame 0
-frame = reader.slice(7).flatten("mcts")                  # name form on a stream → EventFrame
+frame = reader.slice(7)                                  # EventFrame — voxel(bins=5) applied
+
+# a repr-less reader yields a stream; name the representation on the slice:
+frame = ecv.open("huge.hdf5", dt_ms=30).slice(7).flatten("mcts")   # → EventFrame
 ```
 
 `"pset"` and `"labels"` are not valid names here — `pset` is sparse (see above), and `labels`

--- a/docs/tutorials/02-transforms-and-representations.ipynb
+++ b/docs/tutorials/02-transforms-and-representations.ipynb
@@ -179,11 +179,7 @@
    "cell_type": "markdown",
    "id": "a2df7c5f",
    "metadata": {},
-   "source": [
-    "## As a PyTorch dataset\n",
-    "\n",
-    "`open(..., repr=…)` gives the reader a **default representation**. Every slice remembers it, so `reader.slice(n).view()` renders that representation instead of raw polarity (pass a name to `view(...)` to override). It also makes the reader a map-style dataset: `len(ds)` frames, `ds[i]` a `[C, H, W]` array, and `ds.batch(idx)` a `[B, C, H, W]` stack — no PyTorch needed to produce the arrays."
-   ]
+   "source": "## As a PyTorch dataset\n\n`open(..., repr=…)` makes the reader a **representation source**. Every slice-yielding call — `slice`, `slice_count`, and each item from `windows()` — applies it and returns the rendered `EventFrame`, so `reader.slice(n)` is the frame directly (call `.view()` to display it or `.numpy()` for the array). It also makes the reader a map-style dataset: `len(ds)` frames, `ds[i]` a `[C, H, W]` array, and `ds.batch(idx)` a `[B, C, H, W]` stack — no PyTorch needed to produce the arrays."
   },
   {
    "cell_type": "code",

--- a/docs/tutorials/03-streaming-large-files.ipynb
+++ b/docs/tutorials/03-streaming-large-files.ipynb
@@ -18,10 +18,10 @@
    "id": "a6f216cc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:59:47.429871Z",
-     "iopub.status.busy": "2026-07-03T23:59:47.429498Z",
-     "iopub.status.idle": "2026-07-03T23:59:47.548364Z",
-     "shell.execute_reply": "2026-07-03T23:59:47.532375Z"
+     "iopub.execute_input": "2026-07-09T23:11:07.526276Z",
+     "iopub.status.busy": "2026-07-09T23:11:07.525998Z",
+     "iopub.status.idle": "2026-07-09T23:11:07.742818Z",
+     "shell.execute_reply": "2026-07-09T23:11:07.737489Z"
     }
    },
    "outputs": [
@@ -70,10 +70,10 @@
    "id": "a77f88d7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:59:47.564165Z",
-     "iopub.status.busy": "2026-07-03T23:59:47.562753Z",
-     "iopub.status.idle": "2026-07-03T23:59:47.585591Z",
-     "shell.execute_reply": "2026-07-03T23:59:47.577004Z"
+     "iopub.execute_input": "2026-07-09T23:11:07.753295Z",
+     "iopub.status.busy": "2026-07-09T23:11:07.752895Z",
+     "iopub.status.idle": "2026-07-09T23:11:07.758873Z",
+     "shell.execute_reply": "2026-07-09T23:11:07.757684Z"
     }
    },
    "outputs": [
@@ -106,10 +106,10 @@
    "id": "4a1f31a4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:59:47.614657Z",
-     "iopub.status.busy": "2026-07-03T23:59:47.614154Z",
-     "iopub.status.idle": "2026-07-03T23:59:47.651053Z",
-     "shell.execute_reply": "2026-07-03T23:59:47.633833Z"
+     "iopub.execute_input": "2026-07-09T23:11:07.763184Z",
+     "iopub.status.busy": "2026-07-09T23:11:07.762919Z",
+     "iopub.status.idle": "2026-07-09T23:11:07.767914Z",
+     "shell.execute_reply": "2026-07-09T23:11:07.766973Z"
     }
    },
    "outputs": [
@@ -130,6 +130,49 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8b35a859",
+   "metadata": {},
+   "source": [
+    "## Slices as representations\n",
+    "\n",
+    "Pass `repr=` and the reader becomes a **representation source**: `slice`, `slice_count`, and every `windows()` item come back as the rendered `EventFrame` instead of a raw stream — so `open(path, repr=\"count\").slice(0)` is exactly `open(path).slice(0).count()`. (`reader[i]` still gives the dense `[C, H, W]` array for the PyTorch dataset path — see the [transforms tutorial](02-transforms-and-representations.ipynb).)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "1a71f06d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T23:11:07.772931Z",
+     "iopub.status.busy": "2026-07-09T23:11:07.772823Z",
+     "iopub.status.idle": "2026-07-09T23:11:07.801007Z",
+     "shell.execute_reply": "2026-07-09T23:11:07.799905Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "EventFrame | kind: count | shape: (1, 480, 640)\n",
+      "matches manual .count(): True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Give the reader a representation and every slice comes back rendered:\n",
+    "frames = ecv.open(PATH, dt_ms=20, repr=\"count\")\n",
+    "frame = frames.slice(0)                       # an EventFrame — no extra .count() call\n",
+    "print(type(frame).__name__, \"| kind:\", frame.kind, \"| shape:\", frame.numpy().shape)\n",
+    "\n",
+    "# open(repr=…).slice(n) is exactly open().slice(n).count():\n",
+    "manual = ecv.open(PATH, dt_ms=20).slice(0).count()\n",
+    "print(\"matches manual .count():\", np.array_equal(frame.numpy(), manual.numpy()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "5c1c08a6",
    "metadata": {},
    "source": [
@@ -140,14 +183,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "49e196b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:59:47.663616Z",
-     "iopub.status.busy": "2026-07-03T23:59:47.663158Z",
-     "iopub.status.idle": "2026-07-03T23:59:47.680583Z",
-     "shell.execute_reply": "2026-07-03T23:59:47.679010Z"
+     "iopub.execute_input": "2026-07-09T23:11:07.804666Z",
+     "iopub.status.busy": "2026-07-09T23:11:07.803921Z",
+     "iopub.status.idle": "2026-07-09T23:11:07.819892Z",
+     "shell.execute_reply": "2026-07-09T23:11:07.818600Z"
     }
    },
    "outputs": [
@@ -180,9 +223,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "hotpix02",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T23:11:07.823278Z",
+     "iopub.status.busy": "2026-07-09T23:11:07.823051Z",
+     "iopub.status.idle": "2026-07-09T23:11:07.850719Z",
+     "shell.execute_reply": "2026-07-09T23:11:07.850324Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",

--- a/python/eventcv/load.py
+++ b/python/eventcv/load.py
@@ -157,9 +157,12 @@ def open(
     ``slice``/``windows``/``with_repr``. To render an algorithm as a video, map it over
     ``windows()`` and hand the frames to :func:`export_png` (then assemble with ffmpeg).
 
-    Note ``repr`` governs the **array/dataset** path (``reader[i]`` → NumPy). To *view* a slice
-    interactively, ``slice(i)`` returns the raw :class:`EventStream`, so name the representation
-    on the stream: ``data.slice(1000).view("flow")`` (or ``.slice(1000).optical_flow().view()``).
+    When ``repr`` is set, ``slice``/``slice_count``/``windows`` also apply it: each returns the
+    rendered :class:`EventFrame` (the rich object — ``.numpy()``, ``.view()``, ``.save()``),
+    while ``reader[i]``/``batch`` stay dense NumPy arrays for the ``DataLoader`` path. So
+    ``open(path, repr="mcts").slice(0)`` equals ``open(path).slice(0).mcts()``. Without ``repr``,
+    ``slice(i)`` returns the raw :class:`EventStream`, so name the representation on the stream:
+    ``data.slice(1000).view("flow")`` (or ``.slice(1000).optical_flow().view()``).
 
     Example::
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -379,18 +379,26 @@ class DatasetReaderTests(unittest.TestCase):
         self.assertEqual(reader[0].shape, (5, 8, 8))
         self.assertEqual(reader[0].dtype, np.float32)
 
-    def test_slice_carries_open_repr(self):
-        # A slice from a reader opened with a representation remembers it, so `view()`/
-        # `flatten()` render that repr instead of the default polarity image.
+    def test_slice_renders_open_repr(self):
+        # A reader opened with a representation is a frame source: slice()/slice_count()/
+        # windows() render each slice to that EventFrame instead of returning a raw stream.
         reader = self._dataset(repr="voxel")
-        stream = reader.slice(0)
-        self.assertIsInstance(stream, eventcv.EventStream)
-        self.assertEqual(stream.repr, "voxel")
-        self.assertEqual(stream.flatten().kind, "voxel")  # no explicit repr -> the stored one
-        # Transforms and windows keep it; an explicit argument still overrides it.
-        self.assertEqual(stream.flip_x().repr, "voxel")
-        self.assertEqual(next(reader.windows()).repr, "voxel")
-        self.assertEqual(stream.flatten("count").kind, "count")
+        frame = reader.slice(0)
+        self.assertIsInstance(frame, eventcv.EventFrame)
+        self.assertEqual(frame.kind, "voxel")
+        self.assertEqual(reader.slice_count(0, 4).kind, "voxel")
+        self.assertEqual(next(reader.windows()).kind, "voxel")
+
+    def test_slice_render_matches_manual_repr(self):
+        # open(repr=…).slice(n) == open().slice(n).<repr>()  (the reported bug): opening
+        # with a representation auto-applies it to each slice.
+        path = Path(tempfile.mkdtemp()) / "events.txt"
+        path.write_text("0 0 0 1\n10 1 1 0\n20 2 2 1\n30 3 3 0\n")
+        kwargs = dict(dt_ms=0.01, sensor_size=(8, 8), time_unit="us")
+        auto = eventcv.open(str(path), repr="count", **kwargs).slice(0)
+        manual = eventcv.open(str(path), **kwargs).slice(0).count()
+        self.assertEqual(auto.kind, manual.kind)
+        np.testing.assert_array_equal(auto.numpy(), manual.numpy())
 
     def test_slice_has_no_repr_without_open_repr(self):
         path = Path(tempfile.mkdtemp()) / "events.txt"
@@ -458,8 +466,8 @@ class DatasetReaderTests(unittest.TestCase):
         self.assertEqual(reader[0].shape, (1, 8, 8))
         self.assertEqual(int(reader[0].sum()), 2)  # raw counts: 2 events per slice
         self.assertEqual(reader.batch([0, 1]).shape, (2, 1, 8, 8))
-        stream = reader.slice(1)
-        self.assertEqual(stream.repr, "count")  # open(repr=…) survives count slicing
+        frame = reader.slice(1)
+        self.assertEqual(frame.kind, "count")  # open(repr=…) renders count slices
 
     def test_open_rejects_dt_ms_with_max_events(self):
         path = Path(tempfile.mkdtemp()) / "events.txt"


### PR DESCRIPTION
## Description
This PR contributes a fix that allows users to fix an `EventReader` object to a particular representation when using `ecv.load()`, simplifying later representation calls if you only require one representation type. When parsing `repr=` in load, prior behaviour only applied the specified representation to `view()`, but not the actual event stream.

### Prior behaviour
```python
import eventcv as ecv

data=ecv.open('stream.hdf5', repr='mcts')
slice0 = data.slice(0).numpy()
print(slice0.shape)

# returns a [n, 4] array of n events
```

### New behaviour
```python
import eventcv as ecv

data=ecv.open('stream.hdf5', repr='mcts')
slice0 = data.slice(0).numpy()
print(slice0.shape)

# returns a [10, 260, 346] array of an mcts representation
```

## Related Issue
Resolves #6 

## Checklist and questions
- [x] My code follows the style and [contribution guidelines](https://github.com/EventLAB-Team/eventcv/tree/main?tab=contributing-ov-file) of this project
- [ ] If adding a new feature, I have created the relevant `test/` and have verified that it passes
- [x] I have made alterations to pre-existing functions