### PR TITLE
Add extensible event stream GUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,96 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 
 [[package]]
+name = "accesskit"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99b76d84ee70e30a4a7e39ab9018e2b17a6a09e31084176cc7c0b2dec036ba45"
+
+[[package]]
+name = "accesskit_atspi_common"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5393c75d4666f580f4cac0a968bc97c36076bb536a129f28210dac54ee127ed"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "atspi-common",
+ "serde",
+ "thiserror 1.0.69",
+ "zvariant",
+]
+
+[[package]]
+name = "accesskit_consumer"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a12dc159d52233c43d9fe5415969433cbdd52c3d6e0df51bda7d447427b9986"
+dependencies = [
+ "accesskit",
+ "immutable-chunkmap",
+]
+
+[[package]]
+name = "accesskit_macos"
+version = "0.17.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfc6c1ecd82053d127961ad80a8beaa6004fb851a3a5b96506d7a6bd462403f6"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+ "once_cell",
+]
+
+[[package]]
+name = "accesskit_unix"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be7f5cf6165be10a54b2655fa2e0e12b2509f38ed6fc43e11c31fdb7ee6230bb"
+dependencies = [
+ "accesskit",
+ "accesskit_atspi_common",
+ "async-channel",
+ "async-executor",
+ "async-task",
+ "atspi",
+ "futures-lite",
+ "futures-util",
+ "serde",
+ "zbus",
+]
+
+[[package]]
+name = "accesskit_windows"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "974e96c347384d9133427167fb8a58c340cb0496988dacceebdc1ed27071023b"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "paste",
+ "static_assertions",
+ "windows 0.58.0",
+ "windows-core 0.58.0",
+]
+
+[[package]]
+name = "accesskit_winit"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aea3522719f1c44564d03e9469a8e2f3a98b3a8a880bd66d0789c6b9c4a669dd"
+dependencies = [
+ "accesskit",
+ "accesskit_macos",
+ "accesskit_unix",
+ "accesskit_windows",
+ "raw-window-handle",
+ "winit",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,6 +194,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "log",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.59.0",
+ "x11rb",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,10 +244,203 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.4",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "atspi"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be534b16650e35237bb1ed189ba2aab86ce65e88cc84c66f4935ba38575cecbf"
+dependencies = [
+ "atspi-common",
+ "atspi-connection",
+ "atspi-proxies",
+]
+
+[[package]]
+name = "atspi-common"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1909ed2dc01d0a17505d89311d192518507e8a056a48148e3598fef5e7bb6ba7"
+dependencies = [
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zbus",
+ "zbus-lockstep",
+ "zbus-lockstep-macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "atspi-connection"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "430c5960624a4baaa511c9c0fcc2218e3b58f5dbcc47e6190cafee344b873333"
+dependencies = [
+ "atspi-common",
+ "atspi-proxies",
+ "futures-lite",
+ "zbus",
+]
+
+[[package]]
+name = "atspi-proxies"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e6c5de3e524cf967569722446bcd458d5032348554d9a17d7d72b041ab7496"
+dependencies = [
+ "atspi-common",
+ "serde",
+ "zbus",
+ "zvariant",
+]
 
 [[package]]
 name = "autocfg"
@@ -217,7 +517,29 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
- "objc2",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2 0.6.4",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -293,13 +615,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "calloop"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dbf9978365bac10f54d1d4b04f7ce4427e51f71d61f2fe15e3fed5166474df7"
+dependencies = [
+ "bitflags 2.13.0",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "tracing",
+]
+
+[[package]]
 name = "calloop-wayland-source"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
 dependencies = [
- "calloop",
+ "calloop 0.13.0",
  "rustix 0.38.44",
+ "wayland-backend",
+ "wayland-client",
+]
+
+[[package]]
+name = "calloop-wayland-source"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138efcf0940a02ebf0cc8d1eff41a1682a46b431630f4c52450d6265876021fa"
+dependencies = [
+ "calloop 0.14.4",
+ "rustix 1.1.4",
  "wayland-backend",
  "wayland-client",
 ]
@@ -401,6 +748,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
 
 [[package]]
 name = "cmake"
@@ -657,6 +1013,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2 0.6.2",
+ "libc",
+ "objc2 0.6.4",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "dlib"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -687,10 +1066,129 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
+name = "ecolor"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775cfde491852059e386c4e1deb4aef381c617dc364184c6f6afee99b87c402b"
+dependencies = [
+ "bytemuck",
+ "emath",
+]
+
+[[package]]
+name = "egui"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53eafabcce0cb2325a59a98736efe0bf060585b437763f8c476957fb274bb974"
+dependencies = [
+ "accesskit",
+ "ahash",
+ "emath",
+ "epaint",
+ "log",
+ "nohash-hasher",
+]
+
+[[package]]
+name = "egui-wgpu"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d00fd5d06d8405397e64a928fa0ef3934b3c30273ea7603e3dc4627b1f7a1a82"
+dependencies = [
+ "ahash",
+ "bytemuck",
+ "document-features",
+ "egui",
+ "epaint",
+ "log",
+ "thiserror 1.0.69",
+ "type-map",
+ "web-time",
+ "wgpu",
+]
+
+[[package]]
+name = "egui-winit"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a9c430f4f816340e8e8c1b20eec274186b1be6bc4c7dfc467ed50d57abc36c6"
+dependencies = [
+ "accesskit_winit",
+ "ahash",
+ "arboard",
+ "egui",
+ "log",
+ "raw-window-handle",
+ "smithay-clipboard",
+ "web-time",
+ "webbrowser",
+ "winit",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "emath"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1fe0049ce51d0fb414d029e668dd72eb30bc2b739bf34296ed97bd33df544f3"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "epaint"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a32af8da821bd4f43f2c137e295459ee2e1661d87ca8779dfa0eaf45d870e20f"
+dependencies = [
+ "ab_glyph",
+ "ahash",
+ "bytemuck",
+ "ecolor",
+ "emath",
+ "epaint_default_fonts",
+ "log",
+ "nohash-hasher",
+ "parking_lot",
+]
+
+[[package]]
+name = "epaint_default_fonts"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "483440db0b7993cf77a20314f08311dbe95675092405518c0677aa08c151a3ea"
 
 [[package]]
 name = "equivalent"
@@ -709,6 +1207,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5343afd4a8365a643ac588dab4cf234a190c7f6c88c9f6dd6ffe00837661b7"
+
+[[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "eventcv-core"
 version = "1.0.5"
 dependencies = [
@@ -724,7 +1248,7 @@ dependencies = [
  "npyz",
  "ort",
  "png",
- "pollster",
+ "pollster 0.3.0",
  "rand",
  "rand_distr",
  "rayon",
@@ -740,13 +1264,23 @@ name = "eventcv-py"
 version = "1.0.5"
 dependencies = [
  "bytemuck",
+ "egui",
+ "egui-wgpu",
+ "egui-winit",
  "eventcv-core",
  "numpy",
- "pollster",
+ "pollster 0.3.0",
  "pyo3",
+ "rfd",
  "wgpu",
  "winit",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fdeflate"
@@ -807,10 +1341,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
@@ -825,7 +1404,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -944,7 +1527,7 @@ dependencies = [
  "presser",
  "thiserror 1.0.69",
  "winapi",
- "windows",
+ "windows 0.52.0",
 ]
 
 [[package]]
@@ -1092,6 +1675,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hexf-parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1104,6 +1693,119 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
+
+[[package]]
+name = "icu_properties"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
+
+[[package]]
+name = "icu_provider"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "immutable-chunkmap"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45b30d0eb3d4282f694894b75bc50807ab6e3203436681cc235fa364acf7f5e1"
+dependencies = [
+ "arrayvec",
 ]
 
 [[package]]
@@ -1328,6 +2030,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
+
+[[package]]
 name = "litrs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1408,6 +2116,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1531,6 +2248,25 @@ name = "neuromorphic-types"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ba7c9f18cdc800a16d47977472c5c75e96965eef57dbf39d37e937f390d6fef"
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "npyz"
@@ -1664,19 +2400,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2-app-kit"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.5.1",
  "libc",
- "objc2",
+ "objc2 0.5.2",
  "objc2-core-data",
  "objc2-core-image",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
  "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-core-graphics",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -1686,10 +2444,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
- "objc2",
+ "block2 0.5.1",
+ "objc2 0.5.2",
  "objc2-core-location",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -1698,9 +2456,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
 dependencies = [
- "block2",
- "objc2",
- "objc2-foundation",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -1710,9 +2468,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
- "objc2",
- "objc2-foundation",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.13.0",
+ "dispatch2",
+ "objc2 0.6.4",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.13.0",
+ "dispatch2",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-io-surface",
 ]
 
 [[package]]
@@ -1721,9 +2503,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
 dependencies = [
- "block2",
- "objc2",
- "objc2-foundation",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
  "objc2-metal",
 ]
 
@@ -1733,10 +2515,10 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
 dependencies = [
- "block2",
- "objc2",
+ "block2 0.5.1",
+ "objc2 0.5.2",
  "objc2-contacts",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -1752,10 +2534,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.5.1",
  "dispatch",
  "libc",
- "objc2",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -1764,10 +2568,10 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
 dependencies = [
- "block2",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -1777,9 +2581,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
- "objc2",
- "objc2-foundation",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -1789,9 +2593,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
- "objc2",
- "objc2-foundation",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
  "objc2-metal",
 ]
 
@@ -1801,8 +2605,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
 dependencies = [
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -1812,13 +2616,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
- "objc2",
+ "block2 0.5.1",
+ "objc2 0.5.2",
  "objc2-cloud-kit",
  "objc2-core-data",
  "objc2-core-image",
  "objc2-core-location",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
  "objc2-link-presentation",
  "objc2-quartz-core",
  "objc2-symbols",
@@ -1832,9 +2636,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
 dependencies = [
- "block2",
- "objc2",
- "objc2-foundation",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -1844,10 +2648,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
- "objc2",
+ "block2 0.5.1",
+ "objc2 0.5.2",
  "objc2-core-location",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -1870,6 +2674,16 @@ checksum = "5df339f526ea9a60e371768d50efc2f2508c7203290731565d1f7a6f71d21747"
 dependencies = [
  "libc",
  "libredox",
+]
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1899,6 +2713,12 @@ checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
 dependencies = [
  "ttf-parser",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2028,6 +2848,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2073,6 +2904,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22686f4785f02a4fcc856d3b3bb19bf6c8160d103f7a99cc258bddd0251dc7f2"
 
 [[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2085,6 +2922,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -2221,6 +3067,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -2388,6 +3244,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
+name = "rfd"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20dafead71c16a34e1ff357ddefc8afc11e7d51d6d2b9fbd07eaa48e3e540220"
+dependencies = [
+ "block2 0.6.2",
+ "dispatch2",
+ "js-sys",
+ "libc",
+ "log",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "percent-encoding",
+ "pollster 0.4.0",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "web-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rosbag"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2494,7 +3377,7 @@ dependencies = [
  "ab_glyph",
  "log",
  "memmap2",
- "smithay-client-toolkit",
+ "smithay-client-toolkit 0.19.2",
  "tiny-skia",
 ]
 
@@ -2548,6 +3431,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2574,6 +3468,16 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -2625,8 +3529,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
 dependencies = [
  "bitflags 2.13.0",
- "calloop",
- "calloop-wayland-source",
+ "calloop 0.13.0",
+ "calloop-wayland-source 0.3.0",
  "cursor-icon",
  "libc",
  "log",
@@ -2641,6 +3545,44 @@ dependencies = [
  "wayland-protocols-wlr",
  "wayland-scanner",
  "xkeysym",
+]
+
+[[package]]
+name = "smithay-client-toolkit"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0512da38f5e2b31201a93524adb8d3136276fa4fe4aafab4e1f727a82b534cc0"
+dependencies = [
+ "bitflags 2.13.0",
+ "calloop 0.14.4",
+ "calloop-wayland-source 0.4.1",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2",
+ "rustix 1.1.4",
+ "thiserror 2.0.18",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols",
+ "wayland-protocols-experimental",
+ "wayland-protocols-misc",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "xkeysym",
+]
+
+[[package]]
+name = "smithay-clipboard"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71704c03f739f7745053bde45fa203a46c58d25bc5c4efba1d9a60e9dba81226"
+dependencies = [
+ "libc",
+ "smithay-client-toolkit 0.20.0",
+ "wayland-backend",
 ]
 
 [[package]]
@@ -2660,6 +3602,12 @@ checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
 dependencies = [
  "bitflags 2.13.0",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -2702,10 +3650,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "termcolor"
@@ -2801,6 +3784,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2846,8 +3839,21 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2866,6 +3872,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
+name = "type-map"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
+dependencies = [
+ "rustc-hash 2.1.2",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2876,6 +3891,17 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -2900,6 +3926,24 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "vcpkg"
@@ -3054,6 +4098,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-protocols-experimental"
+version = "20250721.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40a1f863128dcaaec790d7b4b396cc9b9a7a079e878e18c47e6c2d2c5a8dcbb1"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-misc"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9567599ef23e09b8dad6e429e5738d4509dfc46b3b21f32841a304d16b29c8"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
 name = "wayland-protocols-plasma"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3086,7 +4156,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
  "proc-macro2",
- "quick-xml",
+ "quick-xml 0.39.4",
  "quote",
 ]
 
@@ -3120,6 +4190,22 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webbrowser"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62c35be770821a214dbc362fc26908c853e776c0004294d0b10b8a6bad582f94"
+dependencies = [
+ "jni",
+ "log",
+ "ndk-context",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
+ "url",
+ "web-sys",
 ]
 
 [[package]]
@@ -3277,7 +4363,17 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
- "windows-core",
+ "windows-core 0.52.0",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
  "windows-targets",
 ]
 
@@ -3291,10 +4387,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-strings",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -3397,9 +4547,9 @@ dependencies = [
  "android-activity",
  "atomic-waker",
  "bitflags 2.13.0",
- "block2",
+ "block2 0.5.1",
  "bytemuck",
- "calloop",
+ "calloop 0.13.0",
  "cfg_aliases 0.2.1",
  "concurrent-queue",
  "core-foundation",
@@ -3410,9 +4560,9 @@ dependencies = [
  "libc",
  "memmap2",
  "ndk",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
  "objc2-ui-kit",
  "orbclient",
  "percent-encoding",
@@ -3421,7 +4571,7 @@ dependencies = [
  "redox_syscall 0.4.1",
  "rustix 0.38.44",
  "sctk-adwaita",
- "smithay-client-toolkit",
+ "smithay-client-toolkit 0.19.2",
  "smol_str",
  "tracing",
  "unicode-segmentation",
@@ -3466,6 +4616,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "writeable"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
+
+[[package]]
 name = "x11-dl"
 version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3504,6 +4660,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b"
 
 [[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "xkbcommon-dl"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3529,6 +4695,128 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-fs",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix",
+ "ordered-stream",
+ "rand",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.52.0",
+ "xdg-home",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus-lockstep"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca2c5dceb099bddaade154055c926bb8ae507a18756ba1d8963fd7b51d8ed1d"
+dependencies = [
+ "zbus_xml",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus-lockstep-macros"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709ab20fc57cb22af85be7b360239563209258430bccf38d8b979c5a2ae3ecce"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "zbus-lockstep",
+ "zbus_xml",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_xml"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f374552b954f6abb4bd6ce979e6c9b38fb9d0cd7cc68a7d796e70c9f3a233"
+dependencies = [
+ "quick-xml 0.30.0",
+ "serde",
+ "static_assertions",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3546,6 +4834,60 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f212a141d820099d57ffafb9569be9617a6f27d3dc881fbee8fb56642f917a9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3619,4 +4961,41 @@ checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "zvariant"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zvariant_derive",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]

--- a/crates/eventcv-py/Cargo.toml
+++ b/crates/eventcv-py/Cargo.toml
@@ -17,6 +17,15 @@ wgpu = "22"
 winit = "0.30"
 pollster = "0.3"   # block on wgpu's async device/adapter requests
 bytemuck = { version = "1", features = ["derive"] }
+# Immediate-mode controls drawn into the viewer's existing winit/wgpu event loop. 0.29.1 is the
+# release that uses the same winit 0.30 / wgpu 22 pair as the renderer above, so Cargo links one
+# graphics stack rather than two.
+egui = "=0.29.1"
+egui-winit = { version = "=0.29.1", features = ["accesskit"] }
+egui-wgpu = "=0.29.1"
+# Native file chooser (XDG portal on Linux, platform dialogs on macOS/Windows). Drag-and-drop and
+# the CLI path remain available when a desktop portal is absent.
+rfd = "=0.17.2"
 
 [features]
 # Build `.h5`/`.hdf5` support into the extension (forwards to eventcv-core, which

--- a/crates/eventcv-py/src/lib.rs
+++ b/crates/eventcv-py/src/lib.rs
@@ -25,8 +25,7 @@ use eventcv_core::{
 };
 use numpy::ndarray::Array2;
 use numpy::{
-    IntoPyArray, PyArray1, PyArray2, PyArray3, PyReadonlyArray1, PyReadonlyArray2,
-    PyReadonlyArray3,
+    IntoPyArray, PyArray1, PyArray2, PyArray3, PyReadonlyArray1, PyReadonlyArray2, PyReadonlyArray3,
 };
 use pyo3::exceptions::{
     PyFileNotFoundError, PyIndexError, PyOSError, PyRuntimeError, PyTypeError, PyValueError,
@@ -64,6 +63,102 @@ const EXPORT_CHUNK: usize = 4_000_000;
 /// few frames tracks the recording closely enough, and bounding it keeps `save_video` from reading
 /// a long file twice just to decide how bright to draw it.
 const CLIM_CALIBRATION_FRAMES: usize = 8;
+
+/// Resolves the GUI's recording-time speed while preserving explicitly requested legacy FPS.
+fn gui_playback_speed(py: Python<'_>, fps: Option<f64>, dt_ms: f64, speed: f64) -> PyResult<f64> {
+    if !(dt_ms.is_finite() && dt_ms > 0.0) {
+        return Err(PyValueError::new_err("dt_ms must be finite and positive"));
+    }
+    if !(speed.is_finite() && speed > 0.0) {
+        return Err(PyValueError::new_err("speed must be finite and positive"));
+    }
+    let Some(fps) = fps else {
+        return Ok(speed);
+    };
+    if !(fps.is_finite() && fps > 0.0) {
+        return Err(PyValueError::new_err("fps must be finite and positive"));
+    }
+    PyErr::warn(
+        py,
+        &py.get_type::<pyo3::exceptions::PyDeprecationWarning>(),
+        std::ffi::CString::new(
+            "fps= is deprecated for interactive playback; use speed=, where 1× follows recording time",
+        )?
+        .as_c_str(),
+        1,
+    )?;
+    Ok(legacy_playback_speed(fps, dt_ms, speed))
+}
+
+/// Old playback advanced one `dt_ms` window at `fps * speed` frames per second.
+fn legacy_playback_speed(fps: f64, dt_ms: f64, speed: f64) -> f64 {
+    speed * fps * dt_ms / 1_000.0
+}
+
+fn gui_decay_ms(decay_ms: Option<f64>) -> PyResult<Option<f64>> {
+    if decay_ms.is_some_and(|value| !value.is_finite() || value <= 0.0) {
+        return Err(PyValueError::new_err(
+            "decay_ms must be finite and positive",
+        ));
+    }
+    Ok(decay_ms)
+}
+
+fn gui_refresh_hz(refresh_hz: f64) -> PyResult<f64> {
+    if !(refresh_hz.is_finite() && (1.0..=240.0).contains(&refresh_hz)) {
+        return Err(PyValueError::new_err(
+            "refresh_hz must be finite and between 1 and 240",
+        ));
+    }
+    Ok(refresh_hz)
+}
+
+/// Opens the player without an initial recording; the Open button, shortcut, or a file drop can
+/// then select one. Kept as a small private-looking binding because Python's public `play` wrapper
+/// also accepts paths, readers, and streams.
+#[pyfunction]
+#[pyo3(signature = (
+    *, fps=None, dt_ms=30.0, decay_ms=None, repr=None, colormap="viridis", clim=None,
+    speed=1.0, refresh_hz=60.0, loop_=false, max_frames=None
+))]
+#[allow(clippy::too_many_arguments)]
+fn play_gui(
+    py: Python<'_>,
+    fps: Option<f64>,
+    dt_ms: f64,
+    decay_ms: Option<f64>,
+    repr: Option<&str>,
+    colormap: &str,
+    clim: Option<f64>,
+    speed: f64,
+    refresh_hz: f64,
+    loop_: bool,
+    max_frames: Option<usize>,
+) -> PyResult<()> {
+    let speed = gui_playback_speed(py, fps, dt_ms, speed)?;
+    let refresh_hz = gui_refresh_hz(refresh_hz)?;
+    let decay_ms = gui_decay_ms(decay_ms)?;
+    if max_frames == Some(0) {
+        return Err(PyValueError::new_err("max_frames must be positive"));
+    }
+    let repr = match repr {
+        None | Some("raw") => None,
+        Some(name) => Some(ReprSpec::named(name, None)?),
+    };
+    let options = viewer::gui::Options {
+        dt_ms,
+        refresh_hz,
+        speed,
+        loop_,
+        max_frames,
+        repr,
+        colormap: parse_colormap(colormap)?,
+        clim,
+        decay_ms,
+    };
+    py.detach(|| viewer::gui::run_empty(options))
+        .map_err(PyRuntimeError::new_err)
+}
 
 #[pyclass(name = "EventStream", frozen)]
 struct PyEventStream {
@@ -263,7 +358,6 @@ impl PyEventStream {
         let polarity = polarity != 0;
         self.wrap(py.detach(|| self.inner.filter_polarity(polarity)))
     }
-
 
     /// Recovers the camera motion that makes the warped events sharpest.
     ///
@@ -720,58 +814,39 @@ impl PyEventStream {
             .into_pyarray(py)
     }
 
-    /// Plays this stream in the interactive window, advancing through it in `dt_ms` steps at `fps`.
+    /// Opens the playback GUI over this in-memory stream.
     ///
     /// The in-memory counterpart of `EventReader.play` — same raw polarity-and-decay view, no file
-    /// and no reader needed. `speed` multiplies the rate; `loop_` restarts at the end.
-    #[pyo3(signature = (*, fps=30.0, dt_ms=30.0, decay_ms=None, speed=1.0, loop_=false))]
+    /// and no reader needed. At `speed=1`, recording time matches wall time; `loop_` restarts at
+    /// the end. Explicit `fps=` preserves the old fixed-frame-rate timing and is deprecated.
+    #[pyo3(signature = (
+        *, fps=None, dt_ms=30.0, decay_ms=None, speed=1.0, refresh_hz=60.0, loop_=false
+    ))]
+    #[allow(clippy::too_many_arguments)]
     fn play(
         &self,
         py: Python<'_>,
-        fps: f64,
+        fps: Option<f64>,
         dt_ms: f64,
         decay_ms: Option<f64>,
         speed: f64,
+        refresh_hz: f64,
         loop_: bool,
     ) -> PyResult<()> {
-        if !(speed.is_finite() && speed > 0.0) {
-            return Err(PyValueError::new_err("speed must be finite and positive"));
-        }
-        let walk = StreamWindows::new(&self.inner, dt_ms)?;
-        let (width, height) = self.inner.sensor_size();
-        let mut surface =
-            eventcv_core::viz::RawSurface::new(width, height, decay_ms.unwrap_or(dt_ms));
-        let mut index = 0usize;
-        let mut done = false;
-        let producer = || -> Result<Option<eventcv_core::viz::Rgb8Image>, String> {
-            if done {
-                return Ok(None);
-            }
-            if index >= walk.frames {
-                if !loop_ {
-                    done = true;
-                    return Ok(None);
-                }
-                index = 0;
-                // Without this the trails from the end of the recording keep fading over the first
-                // frames of the next pass.
-                surface.clear();
-            }
-            surface.update(&walk.window(&self.inner, index));
-            index += 1;
-            Ok(Some(surface.render()))
+        let speed = gui_playback_speed(py, fps, dt_ms, speed)?;
+        let refresh_hz = gui_refresh_hz(refresh_hz)?;
+        let decay_ms = gui_decay_ms(decay_ms)?;
+        let options = viewer::gui::Options {
+            dt_ms,
+            refresh_hz,
+            speed,
+            loop_,
+            decay_ms,
+            ..viewer::gui::Options::default()
         };
-        let interval = std::time::Duration::from_secs_f64(1.0 / (fps * speed).clamp(0.1, 1000.0));
-        py.detach(|| {
-            viewer::run_live(
-                producer,
-                width as u32,
-                height as u32,
-                "playback".to_owned(),
-                interval,
-            )
-        })
-        .map_err(PyRuntimeError::new_err)
+        let stream = self.inner.clone();
+        py.detach(|| viewer::gui::run_stream(stream, options))
+            .map_err(PyRuntimeError::new_err)
     }
 
     /// Renders this stream as an animation, returning the number of frames written.
@@ -829,7 +904,8 @@ impl PyEventStream {
                             let frame = py
                                 .detach(|| spec.generate(&window))
                                 .map_err(map_representation_error)?;
-                            extent = extent.max(py.detach(|| eventcv_core::viz::frame_extent(&frame)));
+                            extent =
+                                extent.max(py.detach(|| eventcv_core::viz::frame_extent(&frame)));
                         }
                         if extent > 0.0 {
                             Scale::Fixed(extent)
@@ -1790,7 +1866,9 @@ impl StreamWindows {
         }
         let ts = stream.ts();
         let (Some(&start), Some(&last)) = (ts.first(), ts.last()) else {
-            return Err(PyValueError::new_err("nothing to render: the stream is empty"));
+            return Err(PyValueError::new_err(
+                "nothing to render: the stream is empty",
+            ));
         };
         // The step is in the stream's own raw units, which `dt_ms` is stated in milliseconds
         // against — the same conversion `open(dt_ms=…)` makes.
@@ -2227,7 +2305,9 @@ impl PyEventReader {
 
     /// Applies a 3×3 perspective matrix to each slice.
     fn warp_perspective(&self, matrix: [[f64; 3]; 3]) -> PyEventReader {
-        self.with_slice_op(Arc::new(move |_, s: EventStream| s.warp_perspective(matrix)))
+        self.with_slice_op(Arc::new(move |_, s: EventStream| {
+            s.warp_perspective(matrix)
+        }))
     }
 
     /// Undistorts each slice with a `Camera`'s intrinsics + distortion.
@@ -2242,7 +2322,9 @@ impl PyEventReader {
     fn mask(&self, mask: &Bound<'_, PyAny>) -> PyResult<PyEventReader> {
         let (width, height) = self.sensor_size();
         let flat = parse_mask(mask, (width, height))?;
-        Ok(self.with_slice_op(Arc::new(move |_, s: EventStream| s.mask(&flat, width, height))))
+        Ok(self.with_slice_op(Arc::new(move |_, s: EventStream| {
+            s.mask(&flat, width, height)
+        })))
     }
 
     /// Keeps each slice's events whose timestamp lies in `[t0, t1)` — positionally in
@@ -2374,7 +2456,7 @@ impl PyEventReader {
         Ok(frames)
     }
 
-    /// Plays the recording back in an interactive window — the offline twin of `camera.show()`.
+    /// Opens the recording in the interactive player — the offline twin of `camera.show()`.
     ///
     /// With no representation this is the **raw** view: polarity dots fading over `decay_ms`, the
     /// same [`RawSurface`](eventcv_core::viz::RawSurface) the live viewer draws, so watching a file
@@ -2382,82 +2464,60 @@ impl PyEventReader {
     /// to play that instead. `speed` multiplies the playback rate — `0.25` for a quarter-speed
     /// look at a fast scene — and `dt_ms` sets the window without reopening the reader.
     ///
-    /// Blocks on the main thread until the window is closed (Esc or the close button). `loop_`
-    /// restarts at the end instead of closing.
+    /// Blocks on the main thread until the window is closed. At `speed=1`, recording time matches
+    /// wall time. Explicit `fps=` preserves the old fixed-frame-rate timing and is deprecated.
     #[pyo3(signature = (
-        *, fps=30.0, dt_ms=None, decay_ms=None, repr=None, colormap="viridis", clim=None,
-        speed=1.0, loop_=false, max_frames=None
+        *, fps=None, dt_ms=None, decay_ms=None, repr=None, colormap="viridis", clim=None,
+        speed=1.0, refresh_hz=60.0, loop_=false, max_frames=None
     ))]
     #[allow(clippy::too_many_arguments)]
     fn play(
         &self,
         py: Python<'_>,
-        fps: f64,
+        fps: Option<f64>,
         dt_ms: Option<f64>,
         decay_ms: Option<f64>,
         repr: Option<&str>,
         colormap: &str,
         clim: Option<f64>,
         speed: f64,
+        refresh_hz: f64,
         loop_: bool,
         max_frames: Option<usize>,
     ) -> PyResult<()> {
-        if !(speed.is_finite() && speed > 0.0) {
-            return Err(PyValueError::new_err("speed must be finite and positive"));
-        }
-        let mode = self.render_mode(dt_ms)?;
-        let total = self.frame_count(mode);
-        let frames = max_frames.map_or(total, |limit| limit.min(total));
-        if frames == 0 {
-            return Err(PyValueError::new_err(
-                "nothing to play: the reader has no slices",
-            ));
-        }
-        let mut view = self.render_view(py, repr, colormap, clim, decay_ms, mode, frames)?;
-        let (width, height) = {
-            let guard = self.inner.lock().unwrap();
-            guard.sensor_size()
+        let dt_ms = match dt_ms {
+            Some(dt_ms) => dt_ms,
+            None => match self.mode {
+                Some(SliceMode::Duration(dt_us)) => dt_us as f64 / 1_000.0,
+                _ => DEFAULT_SPAN_MS,
+            },
         };
-
-        // Frames are fetched and rendered inside the producer, on the viewer's own thread. Unlike
-        // the camera path there is no device to starve if this falls behind: a file has no ring
-        // buffer to overflow, so a slow decode just plays slower rather than losing events.
-        let mut index = 0usize;
-        let mut done = false;
-        let producer = || -> Result<Option<eventcv_core::viz::Rgb8Image>, String> {
-            if done {
-                return Ok(None);
-            }
-            if index >= frames {
-                if !loop_ {
-                    done = true;
-                    return Ok(None);
-                }
-                index = 0;
-            }
-            let window = self
-                .window_for_index_in(mode, index as i64)
-                .map_err(|error| error.to_string())?;
-            let stream = Python::attach(|py| {
-                fetch_window(
-                    py,
-                    &self.inner,
-                    window,
-                    index,
-                    self.slice_ops.clone(),
-                    self.hot_pixel_mask.clone(),
-                )
-            })
-            .map_err(|error| error.to_string())?;
-            index += 1;
-            view.render(&stream)
-                .map(Some)
-                .map_err(|error| error.to_string())
+        let speed = gui_playback_speed(py, fps, dt_ms, speed)?;
+        let refresh_hz = gui_refresh_hz(refresh_hz)?;
+        let decay_ms = gui_decay_ms(decay_ms)?;
+        if max_frames == Some(0) {
+            return Err(PyValueError::new_err("max_frames must be positive"));
+        }
+        let repr = match repr {
+            Some("raw") => None,
+            Some(name) => Some(ReprSpec::named(name, None)?),
+            None => self.repr,
         };
-
-        let interval = std::time::Duration::from_secs_f64(1.0 / (fps * speed).clamp(0.1, 1000.0));
-        let title = format!("playback ({}×{})", width, height);
-        viewer::run_live(producer, width as u32, height as u32, title, interval)
+        let options = viewer::gui::Options {
+            dt_ms,
+            refresh_hz,
+            speed,
+            loop_,
+            max_frames,
+            repr,
+            colormap: parse_colormap(colormap)?,
+            clim,
+            decay_ms,
+        };
+        let reader = self.inner.clone();
+        let ops = self.slice_ops.clone();
+        let hot_pixel_mask = self.hot_pixel_mask.clone();
+        py.detach(|| viewer::gui::run_reader(reader, ops, hot_pixel_mask, options))
             .map_err(PyRuntimeError::new_err)
     }
 
@@ -2554,7 +2614,9 @@ impl PyEventReader {
     /// Keeps only events of the given polarity per slice (nonzero / `True` = ON).
     fn filter_polarity(&self, polarity: i64) -> PyEventReader {
         let polarity = polarity != 0;
-        self.with_slice_op(Arc::new(move |_, s: EventStream| s.filter_polarity(polarity)))
+        self.with_slice_op(Arc::new(move |_, s: EventStream| {
+            s.filter_polarity(polarity)
+        }))
     }
 
     /// Flips every event's polarity, per slice.
@@ -2595,7 +2657,9 @@ impl PyEventReader {
     /// Returns a new reader whose every slice is passed through [`EventStream::harris_corners`].
     #[pyo3(signature = (threshold=0.0))]
     fn harris_corners(&self, threshold: f64) -> PyEventReader {
-        self.with_slice_op(Arc::new(move |_, s: EventStream| s.harris_corners(threshold)))
+        self.with_slice_op(Arc::new(move |_, s: EventStream| {
+            s.harris_corners(threshold)
+        }))
     }
 
     /// Renders slice `indices` into one dense `[B, C, H, W]` array — the explicit-batch path
@@ -2770,7 +2834,12 @@ impl PyEventReader {
 
     /// Reads `window` and wraps it for a public slice API: rendered to the reader's
     /// `EventFrame` when a representation is set, else the raw `EventStream`.
-    fn fetch_slice(&self, py: Python<'_>, window: SliceWindow, index: usize) -> PyResult<Py<PyAny>> {
+    fn fetch_slice(
+        &self,
+        py: Python<'_>,
+        window: SliceWindow,
+        index: usize,
+    ) -> PyResult<Py<PyAny>> {
         let stream = fetch_window(
             py,
             &self.inner,
@@ -3281,7 +3350,9 @@ fn simulate(
             }
         };
         let fps = fps.ok_or_else(|| {
-            PyValueError::new_err("simulating from frames needs fps= (a video file carries its own)")
+            PyValueError::new_err(
+                "simulating from frames needs fps= (a video file carries its own)",
+            )
         })?;
         if !(fps.is_finite() && fps > 0.0) {
             return Err(PyValueError::new_err("fps must be finite and positive"));
@@ -3323,7 +3394,8 @@ fn simulate(
                         // sum to one, so this is exactly "linearise" and nothing else. Skipping it
                         // here would make a grey scene simulate differently depending on whether it
                         // arrived as one channel or three.
-                        let level = (values[base + pixel] / divisor * 255.0).clamp(0.0, 255.0) as u8;
+                        let level =
+                            (values[base + pixel] / divisor * 255.0).clamp(0.0, 255.0) as u8;
                         eventcv_core::simulate::linear_luma(level, level, level)
                     };
                 }
@@ -3347,8 +3419,7 @@ fn simulate(
                     .between(before, &luma, width, height, &fractions)
                     .map_err(|error| PyValueError::new_err(error.to_string()))?;
                 for (fraction, frame) in fractions.iter().zip(&between) {
-                    let at = t - us_per_frame
-                        + (f64::from(*fraction) * us_per_frame as f64) as i64;
+                    let at = t - us_per_frame + (f64::from(*fraction) * us_per_frame as f64) as i64;
                     py.detach(|| sink.push(&simulator.push_frame(frame, at)))
                         .map_err(map_io_error)?;
                 }
@@ -4191,7 +4262,12 @@ impl PyTracker {
     /// survives unmatched — what carries it through a brief occlusion.
     #[new]
     #[pyo3(signature = (*, connectivity=8, min_area=4, max_distance=20.0, max_missed=3))]
-    fn new(connectivity: u8, min_area: usize, max_distance: f64, max_missed: usize) -> PyResult<Self> {
+    fn new(
+        connectivity: u8,
+        min_area: usize,
+        max_distance: f64,
+        max_missed: usize,
+    ) -> PyResult<Self> {
         if connectivity != 4 && connectivity != 8 {
             return Err(PyValueError::new_err("connectivity must be 4 or 8"));
         }
@@ -4216,7 +4292,10 @@ impl PyTracker {
         let tracks = py
             .detach(|| self.inner.update(inner).map(|tracks| tracks.to_vec()))
             .map_err(map_cluster_error)?;
-        tracks.iter().map(|track| track_to_dict(py, track)).collect()
+        tracks
+            .iter()
+            .map(|track| track_to_dict(py, track))
+            .collect()
     }
 
     /// The live tracks without advancing the tracker.
@@ -4279,7 +4358,8 @@ impl PyUdpSender {
     /// Sends every event, split across datagrams. Returns how many were sent.
     fn send(&self, py: Python<'_>, stream: PyRef<'_, PyEventStream>) -> PyResult<usize> {
         let inner = &stream.inner;
-        py.detach(|| self.inner.send(inner)).map_err(map_std_io_error)
+        py.detach(|| self.inner.send(inner))
+            .map_err(map_std_io_error)
     }
 
     #[getter]
@@ -4572,9 +4652,7 @@ fn resolve_device(name: Option<&str>) -> PyResult<eventcv_core::accel::Device> {
     match name {
         None => Ok(eventcv_core::accel::default_device()),
         Some(name) => eventcv_core::accel::Device::parse(name).ok_or_else(|| {
-            PyValueError::new_err(format!(
-                "device must be \"cpu\" or \"gpu\", not {name:?}"
-            ))
+            PyValueError::new_err(format!("device must be \"cpu\" or \"gpu\", not {name:?}"))
         }),
     }
 }
@@ -4639,7 +4717,11 @@ impl PyModel {
     /// Returns one array for a single-output graph, or a list in the graph's declared output order.
     /// A missing batch axis is added when the graph asks for one, so a `[C, H, W]` representation
     /// feeds a `[N, C, H, W]` network without the caller reshaping it.
-    fn __call__<'py>(&self, py: Python<'py>, data: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyAny>> {
+    fn __call__<'py>(
+        &self,
+        py: Python<'py>,
+        data: &Bound<'py, PyAny>,
+    ) -> PyResult<Bound<'py, PyAny>> {
         let array = to_f32_array(py, data)?;
         let array = self.match_input_rank(array);
         let mut outputs = py
@@ -4674,9 +4756,9 @@ impl PyModel {
     ) -> PyResult<Bound<'py, PyDict>> {
         let mut bound = Vec::with_capacity(inputs.len());
         for (key, value) in inputs.iter() {
-            let name: String = key.extract().map_err(|_| {
-                PyValueError::new_err("input names must be strings")
-            })?;
+            let name: String = key
+                .extract()
+                .map_err(|_| PyValueError::new_err("input names must be strings"))?;
             bound.push((name, to_f32_array(py, &value)?));
         }
         let session = &self.inner;
@@ -4764,11 +4846,13 @@ fn to_f32_array(py: Python<'_>, data: &Bound<'_, PyAny>) -> PyResult<numpy::ndar
     let array = data
         .call_method1("astype", ("float32",))
         .unwrap_or_else(|_| data.clone());
-    let readonly = array.extract::<numpy::PyReadonlyArrayDyn<f32>>().map_err(|_| {
-        PyValueError::new_err(
-            "model input must be an EventFrame or a numpy array convertible to float32",
-        )
-    })?;
+    let readonly = array
+        .extract::<numpy::PyReadonlyArrayDyn<f32>>()
+        .map_err(|_| {
+            PyValueError::new_err(
+                "model input must be an EventFrame or a numpy array convertible to float32",
+            )
+        })?;
     Ok(readonly.as_array().to_owned())
 }
 
@@ -5595,10 +5679,15 @@ impl PyEventCamera {
     /// (polarity dots with exponential decay — the default view). Pass a representation name
     /// (`"count"`, `"tencode"`, `"voxel"`, …) to render that live instead, `"raw"` to force the
     /// raw view, or `"aps"` to watch the sensor's own greyscale video (DAVIS only — every other
-    /// camera shows nothing, having no APS array). Blocks on the main thread until the window is
-    /// closed. `decay_ms` tunes the raw fade; `colormap` / `normalize` apply to representations
-    /// and to the APS view.
-    #[pyo3(signature = (representation=None, *, decay_ms=None, colormap="viridis", normalize=true))]
+    /// camera shows nothing, having no APS array). The event view shares the recording player's
+    /// accumulation, refresh, statistics, and processor controls; its bounded freshness queue keeps
+    /// capture and `record=` running while display is paused. Blocks until the window is closed.
+    /// `decay_ms` tunes the raw fade; `colormap` / `normalize` apply to representations and APS.
+    #[pyo3(signature = (
+        representation=None, *, decay_ms=None, colormap="viridis", normalize=true,
+        dt_ms=30.0, refresh_hz=60.0
+    ))]
+    #[allow(clippy::too_many_arguments)]
     fn show(
         &mut self,
         py: Python<'_>,
@@ -5606,16 +5695,54 @@ impl PyEventCamera {
         decay_ms: Option<f64>,
         colormap: &str,
         normalize: bool,
+        dt_ms: f64,
+        refresh_hz: f64,
     ) -> PyResult<()> {
-        self.live(
-            py,
-            representation,
+        if representation.as_deref() == Some("aps") {
+            self.live(
+                py,
+                representation,
+                decay_ms,
+                colormap,
+                normalize,
+                LiveMode::Show,
+            )?;
+            return Ok(());
+        }
+        let _ = gui_playback_speed(py, None, dt_ms, 1.0)?;
+        let refresh_hz = gui_refresh_hz(refresh_hz)?;
+        let decay_ms = Some(gui_decay_ms(decay_ms)?.unwrap_or(self.decay_ms));
+        let repr = match representation.as_deref() {
+            None => self.repr,
+            Some("raw") => None,
+            Some(name) => Some(ReprSpec::named(name, Some(normalize))?),
+        };
+        let options = viewer::gui::Options {
+            dt_ms,
+            refresh_hz,
+            repr,
+            colormap: parse_colormap(colormap)?,
+            clim: (!normalize).then_some(1.0),
             decay_ms,
-            colormap,
-            normalize,
-            LiveMode::Show,
-        )?;
-        Ok(())
+            ..viewer::gui::Options::default()
+        };
+
+        self.park();
+        let (capture, recorder) = match std::mem::replace(&mut self.state, CameraState::Closed) {
+            CameraState::Idle { capture, recorder } => (capture, recorder),
+            _ => return Err(PyRuntimeError::new_err("camera is closed")),
+        };
+        let output = py.detach(move || viewer::gui::run_camera(capture, recorder, options));
+        self.skipped = self.skipped.saturating_add(output.skipped);
+        self.overflows = self.overflows.saturating_add(output.overflows);
+        self.state = match output.capture {
+            Some(capture) => CameraState::Idle {
+                capture,
+                recorder: output.recorder,
+            },
+            None => CameraState::Closed,
+        };
+        output.result.map_err(PyRuntimeError::new_err)
     }
 
     /// Draws a region of interest over the **live** view and returns it as an `(H, W)` boolean
@@ -6033,11 +6160,7 @@ impl PyEventCamera {
 
     /// Files a window's auxiliary streams for `read_frames()` / `read_imu()`, dropping the oldest
     /// once the backlog is full.
-    fn stage_aux(
-        &mut self,
-        frames: Vec<(i64, EventFrame)>,
-        imu: Vec<eventcv_core::io::ImuSample>,
-    ) {
+    fn stage_aux(&mut self, frames: Vec<(i64, EventFrame)>, imu: Vec<eventcv_core::io::ImuSample>) {
         self.n_frames += frames.len();
         self.n_imu += imu.len();
         self.frames.extend(frames);
@@ -6167,7 +6290,6 @@ impl PyEventCamera {
         }
         Ok(())
     }
-
 }
 
 /// Validates the source-side caps before the camera is opened, so a bad rate or rectangle raises
@@ -6631,6 +6753,7 @@ fn _rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(load, m)?)?;
     m.add_function(wrap_pyfunction!(from_numpy, m)?)?;
     m.add_function(wrap_pyfunction!(open, m)?)?;
+    m.add_function(wrap_pyfunction!(play_gui, m)?)?;
     m.add_function(wrap_pyfunction!(save, m)?)?;
     m.add_function(wrap_pyfunction!(load_frame, m)?)?;
     m.add_function(wrap_pyfunction!(bag_topics, m)?)?;
@@ -6666,4 +6789,15 @@ fn _rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
         m.add_function(wrap_pyfunction!(record, m)?)?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::legacy_playback_speed;
+
+    #[test]
+    fn legacy_fps_maps_to_recording_time_speed() {
+        assert_eq!(legacy_playback_speed(30.0, 30.0, 1.0), 0.9);
+        assert_eq!(legacy_playback_speed(100.0, 10.0, 0.5), 0.5);
+    }
 }

--- a/crates/eventcv-py/src/viewer.rs
+++ b/crates/eventcv-py/src/viewer.rs
@@ -8,6 +8,7 @@ use eventcv_core::representation::{EventFrame, EventFrameData, EventPointSet, Re
 use eventcv_core::viz::{render_frame, Colormap, Rgb8Image};
 
 mod gpu;
+pub(crate) mod gui;
 pub(crate) mod roi;
 
 // Polarity colours shared by every cloud (positive = warm, negative = cool).
@@ -40,9 +41,8 @@ pub(crate) enum Scene {
 /// the raw view, or a colour-mapped representation), so the viewer just uploads and displays the
 /// latest.
 ///
-/// The producer is the only thing that knows where the frames come from, so a live camera and a
-/// recording played back from disk both run through here — the latter simply asks for a different
-/// `interval`.
+/// Used by the live-camera path; recorded playback has its own egui app and worker thread.
+#[cfg(feature = "camera")]
 pub(crate) fn run_live<P>(
     producer: P,
     width: u32,
@@ -269,9 +269,13 @@ mod tests {
         // Mirrors `view` without opening a window: image vs cloud dispatch.
         use eventcv_core::representation::RepresentationKind::*;
         match frame.kind() {
-            Polarity | Binary | Count | CountMask | Flow | Intensity | Labels | Tencode => Scene::Image(
-                eventcv_core::viz::render_frame(frame, Colormap::Viridis, true),
-            ),
+            Polarity | Binary | Count | CountMask | Flow | Intensity | Labels | Tencode => {
+                Scene::Image(eventcv_core::viz::render_frame(
+                    frame,
+                    Colormap::Viridis,
+                    true,
+                ))
+            }
             Voxel => Scene::Cloud {
                 points: voxel_cloud(frame).unwrap(),
                 name: String::new(),

--- a/crates/eventcv-py/src/viewer/gpu.rs
+++ b/crates/eventcv-py/src/viewer/gpu.rs
@@ -15,6 +15,7 @@ use wgpu::util::DeviceExt;
 use winit::application::ApplicationHandler;
 use winit::dpi::{LogicalSize, PhysicalSize};
 use winit::event::{ElementState, MouseButton, MouseScrollDelta, WindowEvent};
+use winit::event_loop::EventLoopProxy;
 use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
 use winit::keyboard::{Key, NamedKey};
 use winit::platform::run_on_demand::EventLoopExtRunOnDemand;
@@ -42,8 +43,20 @@ const DEFAULT_PITCH: f32 = -0.55;
 /// Live viewer refresh cadence (~60 FPS).
 const FRAME_INTERVAL: std::time::Duration = std::time::Duration::from_millis(16);
 
+/// Events shared by every app using the process-global event loop. The old viewers ignore these;
+/// the GUI uses the AccessKit event to expose egui's labelled controls to platform screen readers.
+pub(super) enum UserEvent {
+    AccessKit(egui_winit::accesskit_winit::Event),
+}
+
+impl From<egui_winit::accesskit_winit::Event> for UserEvent {
+    fn from(event: egui_winit::accesskit_winit::Event) -> Self {
+        Self::AccessKit(event)
+    }
+}
+
 thread_local! {
-    static EVENT_LOOP: RefCell<Option<EventLoop<()>>> = const { RefCell::new(None) };
+    static EVENT_LOOP: RefCell<Option<EventLoop<UserEvent>>> = const { RefCell::new(None) };
 }
 
 /// Opens a window and renders `scene` until the user closes it (Esc / window close).
@@ -57,9 +70,8 @@ pub(crate) fn run(scene: Scene) -> Result<(), String> {
 /// changed since the last call, or `Err` to abort. Reuses the same process-global event loop as
 /// [`run`], so a session mixes `.view()` and streaming freely (one window at a time).
 ///
-/// Not camera-specific: a recorded file played back at a chosen rate is the same loop with a
-/// different producer, which is why `interval` is a parameter rather than the live viewer's
-/// hardcoded 60 FPS.
+/// `interval` is explicit so each live source can choose its display cadence.
+#[cfg(feature = "camera")]
 pub(crate) fn run_live<P>(
     producer: P,
     width: u32,
@@ -98,13 +110,20 @@ where
 }
 
 /// Runs an app to completion on the process-global event loop, surfacing whatever error ended it.
-fn run_app(mut app: impl ApplicationHandler + Failable) -> Result<(), String> {
+pub(super) fn run_app(
+    mut app: impl ApplicationHandler<UserEvent> + Failable,
+) -> Result<(), String> {
     EVENT_LOOP.with(|cell| {
         let mut slot = cell.borrow_mut();
         if slot.is_none() {
-            *slot = Some(EventLoop::new().map_err(|error| error.to_string())?);
+            *slot = Some(
+                EventLoop::<UserEvent>::with_user_event()
+                    .build()
+                    .map_err(|error| error.to_string())?,
+            );
         }
         let event_loop = slot.as_mut().expect("event loop just initialised");
+        app.set_event_loop_proxy(event_loop.create_proxy());
         event_loop
             .run_app_on_demand(&mut app)
             .map_err(|error| error.to_string())?;
@@ -116,8 +135,10 @@ fn run_app(mut app: impl ApplicationHandler + Failable) -> Result<(), String> {
 }
 
 /// An app that can end on a fatal error, so [`run_app`] can report it.
-trait Failable {
+pub(super) trait Failable {
     fn take_error(&mut self) -> Option<String>;
+
+    fn set_event_loop_proxy(&mut self, _proxy: EventLoopProxy<UserEvent>) {}
 }
 
 /// The live counterpart to [`App`]: instead of one static [`Scene`] it pulls a frame from `producer`
@@ -246,7 +267,7 @@ where
     }
 }
 
-impl<P> ApplicationHandler for LiveApp<'_, P>
+impl<P> ApplicationHandler<UserEvent> for LiveApp<'_, P>
 where
     P: FnMut() -> Result<Option<super::Rgb8Image>, String>,
 {
@@ -394,7 +415,7 @@ impl App {
     }
 }
 
-impl ApplicationHandler for App {
+impl ApplicationHandler<UserEvent> for App {
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
         // Idle between events; a prior `shutdown` on a reused loop left it in `Poll`.
         event_loop.set_control_flow(ControlFlow::Wait);
@@ -488,6 +509,70 @@ impl ApplicationHandler for App {
 
 // ---- GPU state -------------------------------------------------------------------------
 
+/// The window surface and device setup shared by the plain viewer and the egui player.
+pub(super) struct GpuContext {
+    pub(super) surface: wgpu::Surface<'static>,
+    pub(super) device: wgpu::Device,
+    pub(super) queue: wgpu::Queue,
+    pub(super) config: wgpu::SurfaceConfiguration,
+}
+
+pub(super) fn create_gpu(window: Arc<Window>) -> Result<GpuContext, String> {
+    // `all()` (not just `PRIMARY`) so machines with no native Vulkan/Metal/DX12 GPU — headless
+    // boxes, VMs, remote desktops — can still reach an OpenGL or software adapter.
+    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+        backends: wgpu::Backends::all(),
+        ..Default::default()
+    });
+    let surface = instance
+        .create_surface(window.clone())
+        .map_err(|error| error.to_string())?;
+    let adapter = request_adapter(&instance, &surface)
+        .ok_or_else(|| "no compatible GPU or software adapter found".to_owned())?;
+    if adapter.get_info().device_type == wgpu::DeviceType::Cpu {
+        eprintln!(
+            "eventcv: no GPU found — falling back to software rendering ({}); the viewer will be slow.",
+            adapter.get_info().name
+        );
+    }
+    let (device, queue) = pollster::block_on(adapter.request_device(
+        &wgpu::DeviceDescriptor {
+            label: Some("eventcv-device"),
+            required_features: wgpu::Features::empty(),
+            required_limits: wgpu::Limits::downlevel_defaults(),
+            memory_hints: wgpu::MemoryHints::Performance,
+        },
+        None,
+    ))
+    .map_err(|error| error.to_string())?;
+
+    let size = window.inner_size();
+    let caps = surface.get_capabilities(&adapter);
+    let format = caps
+        .formats
+        .iter()
+        .copied()
+        .find(wgpu::TextureFormat::is_srgb)
+        .unwrap_or(caps.formats[0]);
+    let config = wgpu::SurfaceConfiguration {
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+        format,
+        width: size.width.max(1),
+        height: size.height.max(1),
+        present_mode: wgpu::PresentMode::AutoVsync,
+        alpha_mode: caps.alpha_modes[0],
+        view_formats: vec![],
+        desired_maximum_frame_latency: 2,
+    };
+    surface.configure(&device, &config);
+    Ok(GpuContext {
+        surface,
+        device,
+        queue,
+        config,
+    })
+}
+
 struct Render {
     surface: wgpu::Surface<'static>,
     device: wgpu::Device,
@@ -539,70 +624,30 @@ fn request_adapter(
         (wgpu::PowerPreference::LowPower, false),
         (wgpu::PowerPreference::None, true),
     ];
-    attempts.into_iter().find_map(|(power_preference, force_fallback_adapter)| {
-        pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
-            power_preference,
-            compatible_surface: Some(surface),
-            force_fallback_adapter,
-        }))
-    })
+    attempts
+        .into_iter()
+        .find_map(|(power_preference, force_fallback_adapter)| {
+            pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference,
+                compatible_surface: Some(surface),
+                force_fallback_adapter,
+            }))
+        })
 }
 
 impl Render {
     fn new(window: Arc<Window>, scene: Scene) -> Result<Self, String> {
-        // `all()` (not just `PRIMARY`) so machines with no native Vulkan/Metal/DX12 GPU — headless
-        // boxes, VMs, remote desktops — can still reach an OpenGL or software adapter and render,
-        // slowly, instead of failing outright. A real GPU is still preferred (see `request_adapter`).
-        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
-            backends: wgpu::Backends::all(),
-            ..Default::default()
-        });
-        let surface = instance
-            .create_surface(window.clone())
-            .map_err(|error| error.to_string())?;
-        let adapter = request_adapter(&instance, &surface)
-            .ok_or_else(|| "no compatible GPU or software adapter found".to_owned())?;
-        if adapter.get_info().device_type == wgpu::DeviceType::Cpu {
-            eprintln!(
-                "eventcv: no GPU found — falling back to software rendering ({}); the viewer will be slow.",
-                adapter.get_info().name
-            );
-        }
-        let (device, queue) = pollster::block_on(adapter.request_device(
-            &wgpu::DeviceDescriptor {
-                label: Some("eventcv-device"),
-                required_features: wgpu::Features::empty(),
-                required_limits: wgpu::Limits::downlevel_defaults(),
-                memory_hints: wgpu::MemoryHints::Performance,
-            },
-            None,
-        ))
-        .map_err(|error| error.to_string())?;
-
-        let size = window.inner_size();
-        let caps = surface.get_capabilities(&adapter);
-        let format = caps
-            .formats
-            .iter()
-            .copied()
-            .find(wgpu::TextureFormat::is_srgb)
-            .unwrap_or(caps.formats[0]);
-        let config = wgpu::SurfaceConfiguration {
-            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-            format,
-            width: size.width.max(1),
-            height: size.height.max(1),
-            present_mode: wgpu::PresentMode::AutoVsync,
-            alpha_mode: caps.alpha_modes[0],
-            view_formats: vec![],
-            desired_maximum_frame_latency: 2,
-        };
-        surface.configure(&device, &config);
+        let GpuContext {
+            surface,
+            device,
+            queue,
+            config,
+        } = create_gpu(window)?;
         let depth = depth_view(&device, config.width, config.height);
 
         let content = match scene {
-            Scene::Cloud { points, .. } => build_cloud(&device, format, &points),
-            Scene::Image(image) => build_image(&device, &queue, format, &image),
+            Scene::Cloud { points, .. } => build_cloud(&device, config.format, &points),
+            Scene::Image(image) => build_image(&device, &queue, config.format, &image),
         };
 
         Ok(Self {

--- a/crates/eventcv-py/src/viewer/gui.rs
+++ b/crates/eventcv-py/src/viewer/gui.rs
@@ -1,0 +1,2288 @@
+//! Lean playback GUI: egui controls rendered through the viewer's process-global winit/wgpu loop.
+//! File IO, event processing and frame generation stay on one worker thread; the main thread only
+//! owns widgets and the GPU surface.
+
+use std::collections::VecDeque;
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+use egui::{Color32, Pos2, Stroke, TextureHandle, TextureOptions, Vec2};
+use egui_wgpu::{Renderer as EguiRenderer, ScreenDescriptor};
+use eventcv_core::io::{self, LoadOptions, MemorySliceSource, Reader};
+use eventcv_core::viz::{Colormap, RawSurface, Rgb8Image, Scale};
+use eventcv_core::EventStream;
+#[cfg(feature = "camera")]
+use eventcv_core::EventStreamBuilder;
+use winit::application::ApplicationHandler;
+use winit::dpi::{LogicalSize, PhysicalSize};
+use winit::event::{ElementState, WindowEvent};
+use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoopProxy};
+use winit::keyboard::{Key, NamedKey};
+use winit::window::{Window, WindowId};
+
+use super::gpu::{self, Failable, GpuContext, UserEvent};
+use crate::{apply_slice_ops, RenderView, ReprSpec, SliceOps};
+
+const DEFAULT_DT_MS: f64 = 30.0;
+const DEFAULT_REFRESH_HZ: f64 = 60.0;
+const MAX_REFRESH_HZ: f64 = 240.0;
+const HISTORY_LIMIT: usize = 2_048;
+const ACTIVE_POLL: Duration = Duration::from_millis(4);
+const IDLE_POLL: Duration = Duration::from_millis(100);
+
+#[derive(Clone, Copy)]
+pub(crate) struct Options {
+    pub(crate) dt_ms: f64,
+    pub(crate) refresh_hz: f64,
+    pub(crate) speed: f64,
+    pub(crate) loop_: bool,
+    pub(crate) max_frames: Option<usize>,
+    pub(crate) repr: Option<ReprSpec>,
+    pub(crate) colormap: Colormap,
+    pub(crate) clim: Option<f64>,
+    pub(crate) decay_ms: Option<f64>,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            dt_ms: DEFAULT_DT_MS,
+            refresh_hz: DEFAULT_REFRESH_HZ,
+            speed: 1.0,
+            loop_: false,
+            max_frames: None,
+            repr: None,
+            colormap: Colormap::Viridis,
+            clim: None,
+            decay_ms: None,
+        }
+    }
+}
+
+struct PlaybackSource {
+    reader: Arc<Mutex<Reader>>,
+    ops: SliceOps,
+    hot_pixel_mask: Option<Arc<[bool]>>,
+    name: String,
+}
+
+impl PlaybackSource {
+    fn opened(path: &Path) -> Result<Self, String> {
+        let reader = io::open(path, LoadOptions::default()).map_err(|error| error.to_string())?;
+        Ok(Self {
+            reader: Arc::new(Mutex::new(reader)),
+            ops: crate::no_slice_ops(),
+            hot_pixel_mask: None,
+            name: path.display().to_string(),
+        })
+    }
+
+    fn metadata(&self) -> Metadata {
+        let guard = self.reader.lock().unwrap();
+        let (width, height) = guard.sensor_size();
+        let (start_us, end_us) = guard.time_span();
+        Metadata {
+            name: self.name.clone(),
+            width,
+            height,
+            n_events: guard.n_events(),
+            start_us,
+            end_us,
+            live: false,
+            skipped_windows: 0,
+        }
+    }
+
+    fn fetch(&self, t0: i64, t1: i64, index: usize) -> Result<EventStream, String> {
+        let stream = self
+            .reader
+            .lock()
+            .map_err(|_| "event reader lock was poisoned".to_owned())?
+            .slice_time(t0, t1)
+            .map_err(|error| error.to_string())?;
+        let stream = match &self.hot_pixel_mask {
+            Some(mask) => stream.drop_masked_pixels(mask),
+            None => stream,
+        };
+        Ok(apply_slice_ops(&self.ops, index, stream))
+    }
+}
+
+#[derive(Clone)]
+struct Metadata {
+    name: String,
+    width: usize,
+    height: usize,
+    n_events: usize,
+    start_us: i64,
+    end_us: i64,
+    live: bool,
+    skipped_windows: usize,
+}
+
+impl Metadata {
+    fn duration_us(&self) -> i64 {
+        if self.n_events == 0 {
+            0
+        } else {
+            self.end_us.saturating_sub(self.start_us).max(0)
+        }
+    }
+
+    fn mean_rate(&self) -> f64 {
+        let seconds = self.duration_us() as f64 / 1_000_000.0;
+        if seconds > 0.0 {
+            self.n_events as f64 / seconds
+        } else {
+            0.0
+        }
+    }
+}
+
+#[derive(Clone, Copy, Default)]
+struct WindowStats {
+    total: u64,
+    positive: u64,
+    negative: u64,
+    rate: f64,
+}
+
+fn window_stats(stream: &EventStream, bin_us: i64) -> WindowStats {
+    let rate = stream.event_rate(bin_us);
+    let total = rate.counts.iter().sum();
+    let positive = rate.positive.iter().sum();
+    let negative = rate.negative.iter().sum();
+    WindowStats {
+        total,
+        positive,
+        negative,
+        rate: total as f64 / (bin_us.max(1) as f64 / 1_000_000.0),
+    }
+}
+
+struct ProcessorPlugin {
+    name: &'static str,
+    default_dt_us: i64,
+    build: fn(i64) -> Box<dyn Processor>,
+}
+
+static PROCESSOR_PLUGINS: [ProcessorPlugin; 2] = [
+    ProcessorPlugin {
+        name: "Background activity",
+        default_dt_us: 25_000,
+        build: |dt_us| Box::new(BackgroundProcessor::new(dt_us)),
+    },
+    ProcessorPlugin {
+        name: "Refractory",
+        default_dt_us: 1_000,
+        build: |dt_us| Box::new(RefractoryProcessor::new(dt_us)),
+    },
+];
+
+#[derive(Clone, Copy)]
+struct ProcessorConfig {
+    plugin: &'static ProcessorPlugin,
+    enabled: bool,
+    dt_us: i64,
+}
+
+impl PartialEq for ProcessorConfig {
+    fn eq(&self, other: &Self) -> bool {
+        std::ptr::eq(self.plugin, other.plugin)
+            && self.enabled == other.enabled
+            && self.dt_us == other.dt_us
+    }
+}
+
+impl ProcessorConfig {
+    fn new(plugin: &'static ProcessorPlugin) -> Self {
+        Self {
+            plugin,
+            enabled: true,
+            dt_us: plugin.default_dt_us,
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        self.plugin.name
+    }
+
+    fn enabled_mut(&mut self) -> &mut bool {
+        &mut self.enabled
+    }
+
+    fn dt_mut(&mut self) -> &mut i64 {
+        &mut self.dt_us
+    }
+
+    fn build(&self) -> Option<Box<dyn Processor>> {
+        self.enabled.then(|| (self.plugin.build)(self.dt_us))
+    }
+}
+
+/// Internal compiled-in processor boundary. The retained input tail makes the existing stateless
+/// EventStream filters behave continuously across playback windows and later live-camera packets.
+trait Processor: Send {
+    fn lookback_us(&self) -> i64;
+    fn process(&mut self, window: (i64, i64), stream: EventStream) -> EventStream;
+    fn reset(&mut self);
+}
+
+fn process_with_history(
+    history: &mut Option<EventStream>,
+    dt_us: i64,
+    window: (i64, i64),
+    stream: EventStream,
+    filter: impl FnOnce(&EventStream) -> EventStream,
+) -> EventStream {
+    let combined = match history.take() {
+        Some(previous) if !previous.is_empty() => previous.concat(&[&stream]),
+        _ => stream,
+    };
+    let filtered = filter(&combined).time_window(window.0, window.1);
+    *history = Some(combined.time_window(window.1.saturating_sub(dt_us), window.1));
+    filtered
+}
+
+struct BackgroundProcessor {
+    dt_us: i64,
+    history: Option<EventStream>,
+}
+
+impl BackgroundProcessor {
+    fn new(dt_us: i64) -> Self {
+        Self {
+            dt_us: dt_us.max(1),
+            history: None,
+        }
+    }
+}
+
+impl Processor for BackgroundProcessor {
+    fn lookback_us(&self) -> i64 {
+        self.dt_us
+    }
+
+    fn process(&mut self, window: (i64, i64), stream: EventStream) -> EventStream {
+        process_with_history(&mut self.history, self.dt_us, window, stream, |events| {
+            events.background_activity_filter(self.dt_us)
+        })
+    }
+
+    fn reset(&mut self) {
+        self.history = None;
+    }
+}
+
+struct RefractoryProcessor {
+    dt_us: i64,
+    history: Option<EventStream>,
+}
+
+impl RefractoryProcessor {
+    fn new(dt_us: i64) -> Self {
+        Self {
+            dt_us: dt_us.max(1),
+            history: None,
+        }
+    }
+}
+
+impl Processor for RefractoryProcessor {
+    fn lookback_us(&self) -> i64 {
+        self.dt_us
+    }
+
+    fn process(&mut self, window: (i64, i64), stream: EventStream) -> EventStream {
+        process_with_history(&mut self.history, self.dt_us, window, stream, |events| {
+            events.refractory_filter(self.dt_us)
+        })
+    }
+
+    fn reset(&mut self) {
+        self.history = None;
+    }
+}
+
+struct Pipeline {
+    processors: Vec<Box<dyn Processor>>,
+}
+
+impl Pipeline {
+    fn new(config: &[ProcessorConfig]) -> Self {
+        Self {
+            processors: config.iter().filter_map(ProcessorConfig::build).collect(),
+        }
+    }
+
+    fn lookback_us(&self) -> i64 {
+        // Chained filters can extend one another's required input history, so sum is the safe bound.
+        self.processors.iter().fold(0_i64, |total, processor| {
+            total.saturating_add(processor.lookback_us())
+        })
+    }
+
+    fn reset(&mut self) {
+        for processor in &mut self.processors {
+            processor.reset();
+        }
+    }
+
+    fn process(&mut self, window: (i64, i64), mut stream: EventStream) -> EventStream {
+        for processor in &mut self.processors {
+            stream = processor.process(window, stream);
+        }
+        stream
+    }
+}
+
+#[derive(Clone, Copy)]
+struct ViewConfig {
+    repr: Option<ReprSpec>,
+    colormap: Colormap,
+    clim: Option<f64>,
+    decay_ms: Option<f64>,
+}
+
+impl From<Options> for ViewConfig {
+    fn from(options: Options) -> Self {
+        Self {
+            repr: options.repr,
+            colormap: options.colormap,
+            clim: options.clim,
+            decay_ms: options.decay_ms,
+        }
+    }
+}
+
+/// Built-in source boundary. File and memory readers share the seekable arm; the camera arm feeds
+/// the same rolling window and processor pipeline without inventing a native plugin ABI.
+enum InputSource {
+    Recording(PlaybackSource),
+    #[cfg(feature = "camera")]
+    Live {
+        pump: Arc<Mutex<crate::capture::Pump>>,
+    },
+}
+
+struct WorkerSource {
+    source: InputSource,
+    metadata: Metadata,
+    view_config: ViewConfig,
+    view: Option<RenderView>,
+    pipeline: Pipeline,
+    pipeline_config: Vec<ProcessorConfig>,
+    raw_window: Option<EventStream>,
+    processed_window: Option<EventStream>,
+    last_start_us: Option<i64>,
+    last_end_us: Option<i64>,
+    last_dt_us: i64,
+}
+
+impl WorkerSource {
+    fn new(source: PlaybackSource, view_config: ViewConfig) -> Self {
+        let metadata = source.metadata();
+        Self {
+            source: InputSource::Recording(source),
+            metadata,
+            view_config,
+            view: None,
+            pipeline: Pipeline::new(&[]),
+            pipeline_config: Vec::new(),
+            raw_window: None,
+            processed_window: None,
+            last_start_us: None,
+            last_end_us: None,
+            last_dt_us: 0,
+        }
+    }
+
+    #[cfg(feature = "camera")]
+    fn live(
+        pump: Arc<Mutex<crate::capture::Pump>>,
+        name: String,
+        width: usize,
+        height: usize,
+        view_config: ViewConfig,
+    ) -> Self {
+        Self {
+            source: InputSource::Live { pump },
+            metadata: Metadata {
+                name,
+                width,
+                height,
+                n_events: 0,
+                start_us: 0,
+                end_us: 0,
+                live: true,
+                skipped_windows: 0,
+            },
+            view_config,
+            view: None,
+            pipeline: Pipeline::new(&[]),
+            pipeline_config: Vec::new(),
+            raw_window: None,
+            processed_window: None,
+            last_start_us: None,
+            last_end_us: None,
+            last_dt_us: 0,
+        }
+    }
+
+    fn recording(&self) -> &PlaybackSource {
+        match &self.source {
+            InputSource::Recording(source) => source,
+            #[cfg(feature = "camera")]
+            InputSource::Live { .. } => unreachable!("live input has its own render path"),
+        }
+    }
+
+    fn reset(&mut self, dt_us: i64, config: &[ProcessorConfig]) {
+        self.pipeline = Pipeline::new(config);
+        self.pipeline.reset();
+        self.pipeline_config = config.to_vec();
+        self.raw_window = None;
+        self.processed_window = None;
+        self.last_start_us = None;
+        self.last_end_us = None;
+        self.last_dt_us = dt_us;
+        self.view = Some(match self.view_config.repr {
+            None => RenderView::Raw(RawSurface::new(
+                self.metadata.width,
+                self.metadata.height,
+                self.view_config.decay_ms.unwrap_or(dt_us as f64 / 1_000.0),
+            )),
+            Some(spec) => RenderView::Repr {
+                spec,
+                colormap: self.view_config.colormap,
+                scale: match self.view_config.clim {
+                    Some(value) if value > 0.0 => Scale::Fixed(value),
+                    _ => Scale::Auto,
+                },
+            },
+        });
+    }
+
+    fn render(&mut self, request: &RenderRequest) -> Result<FrameResult, String> {
+        #[cfg(feature = "camera")]
+        if matches!(self.source, InputSource::Live { .. }) {
+            return self.render_live(request);
+        }
+        let t0 = self.metadata.start_us.saturating_add(request.cursor_us);
+        let t1 = t0.saturating_add(request.dt_us);
+        let incremental = !request.discontinuous
+            && self.recording().ops.is_empty()
+            && self.last_start_us.is_some_and(|last| t0 > last)
+            && self.last_end_us.is_some_and(|last| t0 <= last && t1 > last)
+            && self.last_dt_us == request.dt_us
+            && self.pipeline_config == request.processors;
+        if !incremental || self.view.is_none() {
+            self.reset(request.dt_us, &request.processors);
+            let render_lookback = if self.view_config.repr.is_none() {
+                (self
+                    .view_config
+                    .decay_ms
+                    .unwrap_or(request.dt_us as f64 / 1_000.0)
+                    * 6_500.0)
+                    .round() as i64
+            } else {
+                0
+            };
+            let mut remaining = self.pipeline.lookback_us().saturating_add(render_lookback);
+            let mut end = t0;
+            let mut index = request.index;
+            let mut preroll = Vec::new();
+            while remaining > 0 && end > self.metadata.start_us {
+                let start = end
+                    .saturating_sub(request.dt_us)
+                    .max(self.metadata.start_us);
+                index = index.saturating_sub(1);
+                preroll.push((start, end, index));
+                remaining = remaining.saturating_sub(end - start);
+                end = start;
+            }
+            // Apply source-side lazy operations with the same per-window indices they get during
+            // uninterrupted playback, then warm the GUI processors from oldest to newest.
+            for (start, end, index) in preroll.into_iter().rev() {
+                let pre = self.recording().fetch(start, end, index)?;
+                let processed = self.pipeline.process((start, end), pre);
+                if matches!(&self.view, Some(RenderView::Raw(_))) {
+                    let _ = self
+                        .view
+                        .as_mut()
+                        .expect("reset creates a view")
+                        .render(&processed)
+                        .map_err(|error| error.to_string())?;
+                }
+            }
+        }
+
+        let (raw, processed) = if incremental {
+            let tail_start = self
+                .last_end_us
+                .expect("incremental render has a previous end");
+            let tail = self.recording().fetch(tail_start, t1, request.index)?;
+            let raw = self
+                .raw_window
+                .take()
+                .expect("incremental render has a raw window")
+                .concat(&[&tail])
+                .time_window(t0, t1);
+            let processed_tail = self.pipeline.process((tail_start, t1), tail);
+            let processed = self
+                .processed_window
+                .take()
+                .expect("incremental render has a processed window")
+                .concat(&[&processed_tail])
+                .time_window(t0, t1);
+            (raw, processed)
+        } else {
+            let raw = self.recording().fetch(t0, t1, request.index)?;
+            let processed = self.pipeline.process((t0, t1), raw.clone());
+            (raw, processed)
+        };
+        let raw_stats = window_stats(&raw, request.dt_us);
+        let processed_stats = window_stats(&processed, request.dt_us);
+        let image = self
+            .view
+            .as_mut()
+            .expect("reset creates a view")
+            .render(&processed)
+            .map_err(|error| error.to_string())?;
+        self.raw_window = Some(raw);
+        self.processed_window = Some(processed);
+        self.last_start_us = Some(t0);
+        self.last_end_us = Some(t1);
+        Ok(FrameResult {
+            generation: request.generation,
+            cursor_us: request.cursor_us,
+            image: Some(image),
+            raw: raw_stats,
+            processed: processed_stats,
+            metadata: None,
+        })
+    }
+
+    #[cfg(feature = "camera")]
+    fn render_live(&mut self, request: &RenderRequest) -> Result<FrameResult, String> {
+        let mut reconfigure = request.discontinuous
+            || self.last_dt_us != request.dt_us
+            || self.pipeline_config != request.processors
+            || self.view.is_none();
+        let previous_raw = self.raw_window.take();
+        let previous_processed = self.processed_window.take();
+        let previous_end = self.last_end_us;
+        if reconfigure {
+            self.reset(request.dt_us, &request.processors);
+        }
+
+        let (packet, skipped) = match &self.source {
+            InputSource::Live { pump } => {
+                let pump = pump
+                    .lock()
+                    .map_err(|_| "camera pump lock was poisoned".to_owned())?;
+                (
+                    pump.next_window(Duration::ZERO)?
+                        .map(|window| window.stream),
+                    pump.n_skipped(),
+                )
+            }
+            InputSource::Recording(_) => unreachable!("checked before entering live render"),
+        };
+        let has_packet = packet.is_some();
+        if skipped > self.metadata.skipped_windows && !reconfigure {
+            reconfigure = true;
+            self.reset(request.dt_us, &request.processors);
+        }
+        self.metadata.skipped_windows = skipped;
+
+        if let Some(packet) = packet {
+            self.metadata.n_events = self.metadata.n_events.saturating_add(packet.len());
+            if let (Some(&first), Some(&last)) = (packet.ts().first(), packet.ts().last()) {
+                if self.metadata.n_events == packet.len() {
+                    self.metadata.start_us = first;
+                }
+                self.metadata.end_us = last;
+            }
+            let packet_window = (
+                packet.ts().first().copied().unwrap_or(self.metadata.end_us),
+                packet
+                    .ts()
+                    .last()
+                    .copied()
+                    .unwrap_or(self.metadata.end_us)
+                    .saturating_add(1),
+            );
+            let raw = previous_raw
+                .map(|events| events.concat(&[&packet]))
+                .unwrap_or_else(|| packet.clone());
+            let end = packet_window.1;
+            let start = end.saturating_sub(request.dt_us);
+            let raw = raw.time_window(start, end);
+            let processed = if reconfigure {
+                self.pipeline.process((start, end), raw.clone())
+            } else {
+                let tail = self.pipeline.process(packet_window, packet);
+                previous_processed
+                    .map(|events| events.concat(&[&tail]))
+                    .unwrap_or(tail)
+                    .time_window(start, end)
+            };
+            self.raw_window = Some(raw);
+            self.processed_window = Some(processed);
+            self.last_start_us = Some(start);
+            self.last_end_us = Some(end);
+        } else if reconfigure {
+            let end = previous_end.unwrap_or(0);
+            let start = end.saturating_sub(request.dt_us);
+            let raw = previous_raw
+                .unwrap_or_else(|| {
+                    EventStreamBuilder::new(self.metadata.width, self.metadata.height, 0.001)
+                        .build()
+                })
+                .time_window(start, end);
+            let processed = self.pipeline.process((start, end), raw.clone());
+            self.raw_window = Some(raw);
+            self.processed_window = Some(processed);
+            self.last_start_us = Some(start);
+            self.last_end_us = previous_end;
+        } else {
+            self.raw_window = previous_raw;
+            self.processed_window = previous_processed;
+            self.last_end_us = previous_end;
+        }
+
+        let raw = self.raw_window.clone().unwrap_or_else(|| {
+            EventStreamBuilder::new(self.metadata.width, self.metadata.height, 0.001).build()
+        });
+        let processed = self.processed_window.clone().unwrap_or_else(|| raw.clone());
+        let raw_stats = window_stats(&raw, request.dt_us);
+        let processed_stats = window_stats(&processed, request.dt_us);
+        let image = if has_packet || reconfigure {
+            Some(
+                self.view
+                    .as_mut()
+                    .expect("live reset creates a view")
+                    .render(&processed)
+                    .map_err(|error| error.to_string())?,
+            )
+        } else {
+            None
+        };
+        Ok(FrameResult {
+            generation: request.generation,
+            cursor_us: 0,
+            image,
+            raw: raw_stats,
+            processed: processed_stats,
+            metadata: Some(self.metadata.clone()),
+        })
+    }
+}
+
+#[derive(Clone)]
+struct RenderRequest {
+    generation: u64,
+    cursor_us: i64,
+    dt_us: i64,
+    index: usize,
+    processors: Vec<ProcessorConfig>,
+    discontinuous: bool,
+}
+
+enum Command {
+    SetSource {
+        generation: u64,
+        source: PlaybackSource,
+        view: ViewConfig,
+    },
+    #[cfg(feature = "camera")]
+    SetLive {
+        generation: u64,
+        pump: Arc<Mutex<crate::capture::Pump>>,
+        name: String,
+        width: usize,
+        height: usize,
+        view: ViewConfig,
+    },
+    Open {
+        generation: u64,
+        path: PathBuf,
+        view: ViewConfig,
+    },
+    Render(RenderRequest),
+    Shutdown,
+}
+
+struct FrameResult {
+    generation: u64,
+    cursor_us: i64,
+    image: Option<Rgb8Image>,
+    raw: WindowStats,
+    processed: WindowStats,
+    metadata: Option<Metadata>,
+}
+
+enum ResultMessage {
+    Loaded { generation: u64, metadata: Metadata },
+    Frame(FrameResult),
+    Error { generation: u64, message: String },
+}
+
+fn worker_loop(commands: Receiver<Command>, results: Sender<ResultMessage>) {
+    let mut source: Option<WorkerSource> = None;
+    let mut queued = None;
+    loop {
+        let command = match queued.take() {
+            Some(command) => command,
+            None => match commands.recv() {
+                Ok(command) => command,
+                Err(_) => return,
+            },
+        };
+        match command {
+            Command::Shutdown => return,
+            Command::SetSource {
+                generation,
+                source: new_source,
+                view,
+            } => {
+                let new_source = WorkerSource::new(new_source, view);
+                let metadata = new_source.metadata.clone();
+                source = Some(new_source);
+                let _ = results.send(ResultMessage::Loaded {
+                    generation,
+                    metadata,
+                });
+            }
+            #[cfg(feature = "camera")]
+            Command::SetLive {
+                generation,
+                pump,
+                name,
+                width,
+                height,
+                view,
+            } => {
+                let new_source = WorkerSource::live(pump, name, width, height, view);
+                let metadata = new_source.metadata.clone();
+                source = Some(new_source);
+                let _ = results.send(ResultMessage::Loaded {
+                    generation,
+                    metadata,
+                });
+            }
+            Command::Open {
+                generation,
+                path,
+                view,
+            } => match PlaybackSource::opened(&path) {
+                Ok(new_source) => {
+                    let new_source = WorkerSource::new(new_source, view);
+                    let metadata = new_source.metadata.clone();
+                    source = Some(new_source);
+                    let _ = results.send(ResultMessage::Loaded {
+                        generation,
+                        metadata,
+                    });
+                }
+                Err(message) => {
+                    let _ = results.send(ResultMessage::Error {
+                        generation,
+                        message,
+                    });
+                }
+            },
+            Command::Render(mut request) => {
+                // Keep the newest interactive seek/configuration request instead of rendering a
+                // backlog the user can no longer see. Source/open/shutdown commands keep order.
+                while let Ok(next) = commands.try_recv() {
+                    match next {
+                        Command::Render(newer) => request = newer,
+                        other => {
+                            queued = Some(other);
+                            break;
+                        }
+                    }
+                }
+                let result = match source.as_mut() {
+                    Some(source) => source.render(&request).map(ResultMessage::Frame),
+                    None => Err("open a recording before playing".to_owned()),
+                };
+                let message = match result {
+                    Ok(message) => message,
+                    Err(message) => ResultMessage::Error {
+                        generation: request.generation,
+                        message,
+                    },
+                };
+                let _ = results.send(message);
+            }
+        }
+    }
+}
+
+struct RateSample {
+    raw: f64,
+    processed: f64,
+}
+
+struct Model {
+    commands: Sender<Command>,
+    results: Receiver<ResultMessage>,
+    view: ViewConfig,
+    metadata: Option<Metadata>,
+    processors: Vec<ProcessorConfig>,
+    history: VecDeque<RateSample>,
+    cursor_us: i64,
+    dt_us: i64,
+    refresh_hz: f64,
+    speed: f64,
+    loop_: bool,
+    max_frames: Option<usize>,
+    playing: bool,
+    pending: bool,
+    loading: bool,
+    play_after_load: bool,
+    generation: u64,
+    next_due: Instant,
+    raw_stats: WindowStats,
+    processed_stats: WindowStats,
+    error: Option<String>,
+    image: Option<Rgb8Image>,
+    texture: Option<TextureHandle>,
+    image_size: [usize; 2],
+}
+
+impl Model {
+    fn new(commands: Sender<Command>, results: Receiver<ResultMessage>, options: Options) -> Self {
+        Self {
+            commands,
+            results,
+            view: options.into(),
+            metadata: None,
+            processors: Vec::new(),
+            history: VecDeque::new(),
+            cursor_us: 0,
+            dt_us: ms_to_us(options.dt_ms),
+            refresh_hz: options.refresh_hz.clamp(1.0, MAX_REFRESH_HZ),
+            speed: options.speed,
+            loop_: options.loop_,
+            max_frames: options.max_frames,
+            playing: false,
+            pending: false,
+            loading: false,
+            play_after_load: false,
+            generation: 0,
+            next_due: Instant::now(),
+            raw_stats: WindowStats::default(),
+            processed_stats: WindowStats::default(),
+            error: None,
+            image: None,
+            texture: None,
+            image_size: [0, 0],
+        }
+    }
+
+    fn next_generation(&mut self) -> u64 {
+        self.generation = self.generation.wrapping_add(1);
+        self.generation
+    }
+
+    fn set_initial_source(&mut self, source: PlaybackSource) {
+        let generation = self.next_generation();
+        self.loading = true;
+        self.pending = true;
+        self.play_after_load = true;
+        let _ = self.commands.send(Command::SetSource {
+            generation,
+            source,
+            view: self.view,
+        });
+    }
+
+    #[cfg(feature = "camera")]
+    fn set_live_source(
+        &mut self,
+        pump: Arc<Mutex<crate::capture::Pump>>,
+        name: String,
+        width: usize,
+        height: usize,
+    ) {
+        let generation = self.next_generation();
+        self.loading = true;
+        self.pending = true;
+        self.play_after_load = true;
+        let _ = self.commands.send(Command::SetLive {
+            generation,
+            pump,
+            name,
+            width,
+            height,
+            view: self.view,
+        });
+    }
+
+    fn open(&mut self, path: PathBuf) {
+        let generation = self.next_generation();
+        self.loading = true;
+        self.pending = true;
+        self.playing = false;
+        self.play_after_load = false;
+        self.error = None;
+        let _ = self.commands.send(Command::Open {
+            generation,
+            path,
+            view: self.view,
+        });
+    }
+
+    fn choose_file(&mut self) {
+        if let Some(path) = rfd::FileDialog::new()
+            .add_filter(
+                "Event recordings",
+                &[
+                    "npz", "txt", "csv", "h5", "hdf5", "bag", "aedat", "aedat4", "dat", "raw",
+                ],
+            )
+            .pick_file()
+        {
+            self.open(path);
+        }
+    }
+
+    fn poll(&mut self) -> bool {
+        let mut changed = false;
+        while let Ok(message) = self.results.try_recv() {
+            match message {
+                ResultMessage::Loaded {
+                    generation,
+                    metadata,
+                } if generation == self.generation => {
+                    self.metadata = Some(metadata);
+                    self.cursor_us = 0;
+                    self.history.clear();
+                    self.image = None;
+                    self.texture = None;
+                    self.loading = false;
+                    self.pending = false;
+                    self.playing = self.play_after_load
+                        && self
+                            .metadata
+                            .as_ref()
+                            .is_some_and(|meta| meta.live || meta.n_events > 0);
+                    self.request_render(true);
+                    changed = true;
+                }
+                ResultMessage::Frame(frame) if frame.generation == self.generation => {
+                    self.pending = false;
+                    self.cursor_us = frame.cursor_us;
+                    if let Some(metadata) = frame.metadata {
+                        self.metadata = Some(metadata);
+                    }
+                    if let Some(image) = frame.image {
+                        self.raw_stats = frame.raw;
+                        self.processed_stats = frame.processed;
+                        self.image_size = [image.width, image.height];
+                        self.image = Some(image);
+                        self.push_history(frame.raw.rate, frame.processed.rate);
+                        changed = true;
+                    }
+                }
+                ResultMessage::Error {
+                    generation,
+                    message,
+                } if generation == self.generation => {
+                    self.error = Some(message);
+                    self.pending = false;
+                    self.loading = false;
+                    self.playing = false;
+                    changed = true;
+                }
+                _ => {}
+            }
+        }
+        changed
+    }
+
+    fn push_history(&mut self, raw: f64, processed: f64) {
+        self.history.push_back(RateSample { raw, processed });
+        if self.history.len() > HISTORY_LIMIT {
+            self.history.pop_front();
+        }
+    }
+
+    fn max_cursor_us(&self) -> i64 {
+        let Some(metadata) = &self.metadata else {
+            return 0;
+        };
+        max_cursor_us(
+            metadata.duration_us(),
+            self.dt_us,
+            self.step_us(),
+            self.max_frames,
+        )
+    }
+
+    fn step_us(&self) -> i64 {
+        (1_000_000.0 * self.speed.max(0.01) / self.refresh_hz.max(1.0))
+            .round()
+            .max(1.0) as i64
+    }
+
+    fn frame_interval(&self) -> Duration {
+        Duration::from_secs_f64(1.0 / self.refresh_hz.max(1.0))
+    }
+
+    fn request_render(&mut self, discontinuous: bool) {
+        let Some(metadata) = &self.metadata else {
+            return;
+        };
+        if metadata.n_events == 0 && !metadata.live {
+            self.pending = false;
+            self.playing = false;
+            return;
+        }
+        self.cursor_us = self.cursor_us.clamp(0, self.max_cursor_us());
+        let generation = self.next_generation();
+        self.pending = true;
+        let index = usize::try_from(self.cursor_us / self.step_us()).unwrap_or(0);
+        let _ = self.commands.send(Command::Render(RenderRequest {
+            generation,
+            cursor_us: self.cursor_us,
+            dt_us: self.dt_us,
+            index,
+            processors: self.processors.clone(),
+            discontinuous,
+        }));
+        self.next_due = Instant::now() + self.frame_interval();
+    }
+
+    fn invalidate(&mut self) {
+        self.history.clear();
+        self.request_render(true);
+    }
+
+    fn tick(&mut self, now: Instant) -> bool {
+        if !self.playing || self.pending || now < self.next_due {
+            return false;
+        }
+        if self.metadata.as_ref().is_some_and(|metadata| metadata.live) {
+            self.request_render(false);
+            return true;
+        }
+        let max = self.max_cursor_us();
+        if self.cursor_us >= max {
+            if self.loop_ && max > 0 {
+                self.cursor_us = 0;
+                self.history.clear();
+                self.request_render(true);
+            } else {
+                self.playing = false;
+            }
+            return true;
+        }
+        self.cursor_us = self.cursor_us.saturating_add(self.step_us()).min(max);
+        self.request_render(false);
+        true
+    }
+
+    fn step(&mut self, direction: i64) {
+        if self.metadata.as_ref().is_none_or(|metadata| metadata.live) {
+            return;
+        }
+        self.playing = false;
+        self.cursor_us = self
+            .cursor_us
+            .saturating_add(self.step_us().saturating_mul(direction))
+            .clamp(0, self.max_cursor_us());
+        self.history.clear();
+        self.request_render(true);
+    }
+
+    fn upload_image(&mut self, context: &egui::Context) {
+        let Some(image) = self.image.take() else {
+            return;
+        };
+        let color = egui::ColorImage::from_rgb([image.width, image.height], &image.pixels);
+        match &mut self.texture {
+            Some(texture) => texture.set(color, TextureOptions::NEAREST),
+            None => {
+                self.texture =
+                    Some(context.load_texture("eventcv-frame", color, TextureOptions::NEAREST));
+            }
+        }
+    }
+
+    fn ui(&mut self, context: &egui::Context) {
+        self.upload_image(context);
+        self.shortcuts(context);
+
+        egui::TopBottomPanel::top("menu").show(context, |ui| {
+            ui.horizontal(|ui| {
+                let live = self.metadata.as_ref().is_some_and(|metadata| metadata.live);
+                if ui
+                    .add_enabled(!live, egui::Button::new("Open…"))
+                    .on_hover_text("Open a recording (Ctrl/Cmd+O)")
+                    .clicked()
+                {
+                    self.choose_file();
+                }
+                if let Some(metadata) = &self.metadata {
+                    ui.label(&metadata.name);
+                } else {
+                    ui.label("Drop a recording here, or choose Open…");
+                }
+                if self.loading {
+                    ui.spinner();
+                    ui.label("Opening…");
+                }
+            });
+            if let Some(error) = &self.error {
+                ui.colored_label(Color32::LIGHT_RED, error);
+            }
+        });
+
+        egui::SidePanel::right("inspector")
+            .default_width(300.0)
+            .show(context, |ui| self.inspector(ui));
+        egui::TopBottomPanel::bottom("transport").show(context, |ui| self.transport(ui));
+        egui::CentralPanel::default().show(context, |ui| self.image_panel(ui));
+
+        if let Some(path) = context.input(|input| {
+            input
+                .raw
+                .dropped_files
+                .iter()
+                .find_map(|file| file.path.clone())
+        }) {
+            if !self.metadata.as_ref().is_some_and(|metadata| metadata.live) {
+                self.open(path);
+            }
+        }
+    }
+
+    fn shortcuts(&mut self, context: &egui::Context) {
+        let open = context.input_mut(|input| {
+            input.consume_shortcut(&egui::KeyboardShortcut::new(
+                egui::Modifiers::COMMAND,
+                egui::Key::O,
+            ))
+        });
+        if open && !self.metadata.as_ref().is_some_and(|metadata| metadata.live) {
+            self.choose_file();
+        }
+        if context.wants_keyboard_input() {
+            return;
+        }
+        if context.input(|input| input.key_pressed(egui::Key::Space))
+            && self
+                .metadata
+                .as_ref()
+                .is_some_and(|meta| meta.live || meta.n_events > 0)
+        {
+            self.playing = !self.playing;
+            self.next_due = Instant::now();
+        }
+        if context.input(|input| input.key_pressed(egui::Key::ArrowLeft)) {
+            self.step(-1);
+        }
+        if context.input(|input| input.key_pressed(egui::Key::ArrowRight)) {
+            self.step(1);
+        }
+    }
+
+    fn transport(&mut self, ui: &mut egui::Ui) {
+        let live = self.metadata.as_ref().is_some_and(|meta| meta.live);
+        let enabled = self
+            .metadata
+            .as_ref()
+            .is_some_and(|meta| meta.live || meta.n_events > 0);
+        ui.add_enabled_ui(enabled, |ui| {
+            ui.horizontal(|ui| {
+                if ui
+                    .add_enabled(!live, egui::Button::new("Previous"))
+                    .on_hover_text("Previous accumulation window (Left)")
+                    .clicked()
+                {
+                    self.step(-1);
+                }
+                if ui
+                    .button(if self.playing { "Pause" } else { "Play" })
+                    .on_hover_text("Play or pause (Space)")
+                    .clicked()
+                {
+                    self.playing = !self.playing;
+                    self.next_due = Instant::now();
+                }
+                if ui
+                    .add_enabled(!live, egui::Button::new("Next"))
+                    .on_hover_text("Next accumulation window (Right)")
+                    .clicked()
+                {
+                    self.step(1);
+                }
+                if live {
+                    ui.label("LIVE");
+                } else {
+                    if ui.checkbox(&mut self.loop_, "Loop").changed() {
+                        self.invalidate();
+                    }
+                    egui::ComboBox::from_label("Speed")
+                        .selected_text(format!("{}×", format_number(self.speed)))
+                        .show_ui(ui, |ui| {
+                            for speed in [0.25, 0.5, 1.0, 2.0, 4.0] {
+                                ui.selectable_value(
+                                    &mut self.speed,
+                                    speed,
+                                    format!("{}×", format_number(speed)),
+                                );
+                            }
+                        });
+                }
+            });
+
+            if !live {
+                let mut seconds = self.cursor_us as f64 / 1_000_000.0;
+                let max_seconds = self.max_cursor_us() as f64 / 1_000_000.0;
+                let response = ui.add(
+                    egui::Slider::new(&mut seconds, 0.0..=max_seconds.max(0.0))
+                        .show_value(false)
+                        .text("Recording position"),
+                );
+                if response.changed() {
+                    self.cursor_us = (seconds * 1_000_000.0).round() as i64;
+                    self.history.clear();
+                    self.request_render(true);
+                }
+                ui.label(format!(
+                    "{} / {}",
+                    format_time(self.cursor_us),
+                    format_time(self.metadata.as_ref().map_or(0, Metadata::duration_us))
+                ));
+            }
+        });
+    }
+
+    fn inspector(&mut self, ui: &mut egui::Ui) {
+        ui.heading("Source");
+        if let Some(metadata) = &self.metadata {
+            egui::Grid::new("file-stats").show(ui, |ui| {
+                stat_row(
+                    ui,
+                    "Sensor",
+                    format!("{} × {}", metadata.width, metadata.height),
+                );
+                stat_row(ui, "Events", format_count(metadata.n_events as u64));
+                stat_row(ui, "Duration", format_time(metadata.duration_us()));
+                stat_row(ui, "Mean rate", format_rate(metadata.mean_rate()));
+                if metadata.live {
+                    stat_row(
+                        ui,
+                        "Skipped windows",
+                        format_count(metadata.skipped_windows as u64),
+                    );
+                }
+            });
+        } else {
+            ui.label("No recording open");
+        }
+
+        ui.separator();
+        ui.heading("Display");
+        let mut dt_ms = self.dt_us as f64 / 1_000.0;
+        let slider = ui.add(
+            egui::Slider::new(&mut dt_ms, 0.1..=1_000.0)
+                .logarithmic(true)
+                .text("Accumulation (ms)"),
+        );
+        let drag = ui
+            .horizontal(|ui| {
+                ui.label("Exact accumulation");
+                ui.add(
+                    egui::DragValue::new(&mut dt_ms)
+                        .range(0.1..=1_000.0)
+                        .speed(0.1)
+                        .suffix(" ms"),
+                )
+            })
+            .inner;
+        if slider.changed() || drag.changed() {
+            self.dt_us = ms_to_us(dt_ms);
+            self.cursor_us = self.cursor_us.min(self.max_cursor_us());
+            self.invalidate();
+        }
+        let refresh = ui.add(
+            egui::Slider::new(&mut self.refresh_hz, 1.0..=MAX_REFRESH_HZ).text("Refresh (Hz)"),
+        );
+        refresh.on_hover_text(
+            "Sliding-window update rate; one render is kept in flight so slow processing applies backpressure",
+        );
+
+        ui.separator();
+        ui.heading("Current window");
+        egui::Grid::new("window-stats").show(ui, |ui| {
+            stat_row(ui, "Raw events", format_count(self.raw_stats.total));
+            stat_row(ui, "Raw rate", format_rate(self.raw_stats.rate));
+            stat_row(
+                ui,
+                "Output events",
+                format_count(self.processed_stats.total),
+            );
+            stat_row(ui, "Processed", format_rate(self.processed_stats.rate));
+            stat_row(
+                ui,
+                "Raw ON / OFF",
+                format!(
+                    "{} / {}",
+                    format_count(self.raw_stats.positive),
+                    format_count(self.raw_stats.negative)
+                ),
+            );
+            stat_row(
+                ui,
+                "Output ON / OFF",
+                format!(
+                    "{} / {}",
+                    format_count(self.processed_stats.positive),
+                    format_count(self.processed_stats.negative)
+                ),
+            );
+            let retained = if self.raw_stats.total == 0 {
+                100.0
+            } else {
+                self.processed_stats.total as f64 / self.raw_stats.total as f64 * 100.0
+            };
+            stat_row(ui, "Retained", format!("{retained:.1}%"));
+        });
+        rate_plot(ui, &self.history);
+
+        ui.separator();
+        ui.heading("Processing");
+        let mut action = None;
+        let mut changed = false;
+        for (index, processor) in self.processors.iter_mut().enumerate() {
+            ui.group(|ui| {
+                ui.horizontal(|ui| {
+                    let name = processor.name();
+                    changed |= ui.checkbox(processor.enabled_mut(), name).changed();
+                    if ui
+                        .small_button("Up")
+                        .on_hover_text("Move earlier")
+                        .clicked()
+                    {
+                        action = Some(PipelineAction::Up(index));
+                    }
+                    if ui
+                        .small_button("Down")
+                        .on_hover_text("Move later")
+                        .clicked()
+                    {
+                        action = Some(PipelineAction::Down(index));
+                    }
+                    if ui.small_button("Remove").clicked() {
+                        action = Some(PipelineAction::Remove(index));
+                    }
+                });
+                ui.horizontal(|ui| {
+                    ui.label("Temporal window");
+                    changed |= ui
+                        .add(
+                            egui::DragValue::new(processor.dt_mut())
+                                .range(1..=1_000_000)
+                                .speed(10.0)
+                                .suffix(" µs"),
+                        )
+                        .on_hover_text("Temporal window in microseconds")
+                        .changed();
+                });
+            });
+        }
+        ui.menu_button("Add processor", |ui| {
+            for plugin in &PROCESSOR_PLUGINS {
+                if ui.button(plugin.name).clicked() {
+                    self.processors.push(ProcessorConfig::new(plugin));
+                    changed = true;
+                    ui.close_menu();
+                }
+            }
+        });
+        if let Some(action) = action {
+            changed |= apply_pipeline_action(&mut self.processors, action);
+        }
+        if changed {
+            self.invalidate();
+        }
+    }
+
+    fn image_panel(&self, ui: &mut egui::Ui) {
+        let Some(texture) = &self.texture else {
+            ui.centered_and_justified(|ui| {
+                ui.label(if self.loading {
+                    "Opening source…"
+                } else {
+                    "Open or drop an event recording"
+                });
+            });
+            return;
+        };
+        let available = ui.available_size();
+        let source = Vec2::new(self.image_size[0] as f32, self.image_size[1] as f32);
+        let scale = (available.x / source.x.max(1.0))
+            .min(available.y / source.y.max(1.0))
+            .max(0.01);
+        let size = source * scale;
+        ui.centered_and_justified(|ui| {
+            ui.add(
+                egui::Image::new(texture)
+                    .fit_to_exact_size(size)
+                    .texture_options(TextureOptions::NEAREST),
+            );
+        });
+    }
+}
+
+enum PipelineAction {
+    Up(usize),
+    Down(usize),
+    Remove(usize),
+}
+
+fn apply_pipeline_action(processors: &mut Vec<ProcessorConfig>, action: PipelineAction) -> bool {
+    match action {
+        PipelineAction::Up(index) if index > 0 => processors.swap(index, index - 1),
+        PipelineAction::Down(index) if index + 1 < processors.len() => {
+            processors.swap(index, index + 1)
+        }
+        PipelineAction::Remove(index) if index < processors.len() => {
+            processors.remove(index);
+        }
+        _ => return false,
+    }
+    true
+}
+
+fn max_cursor_us(duration_us: i64, dt_us: i64, step_us: i64, max_frames: Option<usize>) -> i64 {
+    if duration_us <= 0 || dt_us <= 0 || step_us <= 0 {
+        return 0;
+    }
+    let natural = if duration_us <= dt_us {
+        0
+    } else {
+        duration_us / step_us * step_us
+    };
+    max_frames.map_or(natural, |frames| {
+        natural.min(
+            i64::try_from(frames.saturating_sub(1))
+                .unwrap_or(i64::MAX)
+                .saturating_mul(step_us),
+        )
+    })
+}
+
+fn ms_to_us(milliseconds: f64) -> i64 {
+    (milliseconds.clamp(0.1, 1_000.0) * 1_000.0).round() as i64
+}
+
+fn stat_row(ui: &mut egui::Ui, name: &str, value: String) {
+    ui.label(name);
+    ui.label(value);
+    ui.end_row();
+}
+
+fn format_count(value: u64) -> String {
+    let digits = value.to_string();
+    digits
+        .chars()
+        .rev()
+        .enumerate()
+        .flat_map(|(index, digit)| {
+            (index > 0 && index % 3 == 0)
+                .then_some(',')
+                .into_iter()
+                .chain([digit])
+        })
+        .collect::<String>()
+        .chars()
+        .rev()
+        .collect()
+}
+
+fn format_rate(rate: f64) -> String {
+    if rate >= 1_000_000.0 {
+        format!("{:.2} Mev/s", rate / 1_000_000.0)
+    } else if rate >= 1_000.0 {
+        format!("{:.1} kev/s", rate / 1_000.0)
+    } else {
+        format!("{rate:.0} ev/s")
+    }
+}
+
+fn format_time(microseconds: i64) -> String {
+    let seconds = microseconds.max(0) as f64 / 1_000_000.0;
+    if seconds >= 60.0 {
+        format!("{}:{:05.2}", (seconds / 60.0) as u64, seconds % 60.0)
+    } else {
+        format!("{seconds:.3} s")
+    }
+}
+
+fn format_number(value: f64) -> String {
+    if value.fract() == 0.0 {
+        format!("{value:.0}")
+    } else {
+        value.to_string()
+    }
+}
+
+fn rate_plot(ui: &mut egui::Ui, history: &VecDeque<RateSample>) {
+    let (rect, _) =
+        ui.allocate_exact_size(Vec2::new(ui.available_width(), 110.0), egui::Sense::hover());
+    let painter = ui.painter_at(rect);
+    painter.rect_filled(rect, 4.0, Color32::from_gray(24));
+    if history.len() < 2 {
+        painter.text(
+            rect.center(),
+            egui::Align2::CENTER_CENTER,
+            "Rate history",
+            egui::FontId::default(),
+            Color32::GRAY,
+        );
+        return;
+    }
+    let max_rate = history.iter().fold(1.0_f64, |max, sample| {
+        max.max(sample.raw).max(sample.processed)
+    });
+    let line = |value: fn(&RateSample) -> f64| {
+        history
+            .iter()
+            .enumerate()
+            .map(|(index, sample)| {
+                let x = rect.left() + index as f32 / (history.len() - 1) as f32 * rect.width();
+                let y = rect.bottom() - (value(sample) / max_rate) as f32 * rect.height();
+                Pos2::new(x, y)
+            })
+            .collect::<Vec<_>>()
+    };
+    painter.add(egui::Shape::line(
+        line(|sample| sample.raw),
+        Stroke::new(1.5_f32, Color32::LIGHT_RED),
+    ));
+    painter.add(egui::Shape::line(
+        line(|sample| sample.processed),
+        Stroke::new(1.5_f32, Color32::LIGHT_GREEN),
+    ));
+    painter.text(
+        rect.left_top() + Vec2::new(6.0, 5.0),
+        egui::Align2::LEFT_TOP,
+        "raw / processed",
+        egui::FontId::proportional(11.0),
+        Color32::LIGHT_GRAY,
+    );
+}
+
+struct GuiRender {
+    gpu: GpuContext,
+    context: egui::Context,
+    state: egui_winit::State,
+    renderer: EguiRenderer,
+}
+
+impl GuiRender {
+    fn new(window: Arc<Window>, proxy: EventLoopProxy<UserEvent>) -> Result<Self, String> {
+        let gpu = gpu::create_gpu(window.clone())?;
+        let context = egui::Context::default();
+        let mut state = egui_winit::State::new(
+            context.clone(),
+            egui::ViewportId::ROOT,
+            window.as_ref(),
+            Some(window.scale_factor() as f32),
+            window.theme(),
+            Some(gpu.device.limits().max_texture_dimension_2d as usize),
+        );
+        state.init_accesskit(window.as_ref(), proxy);
+        let renderer = EguiRenderer::new(&gpu.device, gpu.config.format, None, 1, false);
+        Ok(Self {
+            gpu,
+            context,
+            state,
+            renderer,
+        })
+    }
+
+    fn resize(&mut self, size: PhysicalSize<u32>) {
+        if size.width == 0 || size.height == 0 {
+            return;
+        }
+        self.gpu.config.width = size.width;
+        self.gpu.config.height = size.height;
+        self.gpu
+            .surface
+            .configure(&self.gpu.device, &self.gpu.config);
+    }
+
+    fn draw(&mut self, window: &Window, model: &mut Model) -> Result<(), String> {
+        let input = self.state.take_egui_input(window);
+        let output = self.context.run(input, |context| model.ui(context));
+        self.state
+            .handle_platform_output(window, output.platform_output);
+        let pixels_per_point = egui_winit::pixels_per_point(&self.context, window);
+        let paint_jobs = self.context.tessellate(output.shapes, pixels_per_point);
+        for (id, delta) in &output.textures_delta.set {
+            self.renderer
+                .update_texture(&self.gpu.device, &self.gpu.queue, *id, delta);
+        }
+
+        let frame = match self.gpu.surface.get_current_texture() {
+            Ok(frame) => frame,
+            Err(wgpu::SurfaceError::Lost | wgpu::SurfaceError::Outdated) => {
+                self.gpu
+                    .surface
+                    .configure(&self.gpu.device, &self.gpu.config);
+                return Ok(());
+            }
+            Err(wgpu::SurfaceError::Timeout) => return Ok(()),
+            Err(error) => return Err(error.to_string()),
+        };
+        let view = frame
+            .texture
+            .create_view(&wgpu::TextureViewDescriptor::default());
+        let descriptor = ScreenDescriptor {
+            size_in_pixels: [self.gpu.config.width, self.gpu.config.height],
+            pixels_per_point,
+        };
+        let mut encoder = self
+            .gpu
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("eventcv-gui"),
+            });
+        let mut command_buffers = self.renderer.update_buffers(
+            &self.gpu.device,
+            &self.gpu.queue,
+            &mut encoder,
+            &paint_jobs,
+            &descriptor,
+        );
+        {
+            let pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("eventcv-gui-pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color {
+                            r: 0.02,
+                            g: 0.025,
+                            b: 0.05,
+                            a: 1.0,
+                        }),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+            self.renderer
+                .render(&mut pass.forget_lifetime(), &paint_jobs, &descriptor);
+        }
+        command_buffers.push(encoder.finish());
+        self.gpu.queue.submit(command_buffers);
+        frame.present();
+        for id in &output.textures_delta.free {
+            self.renderer.free_texture(id);
+        }
+        Ok(())
+    }
+}
+
+enum InitialSource {
+    Recording(PlaybackSource),
+    #[cfg(feature = "camera")]
+    Live {
+        pump: Arc<Mutex<crate::capture::Pump>>,
+        name: String,
+        width: usize,
+        height: usize,
+    },
+}
+
+struct GuiApp {
+    initial: Option<InitialSource>,
+    model: Model,
+    worker: Option<JoinHandle<()>>,
+    window: Option<Arc<Window>>,
+    render: Option<GuiRender>,
+    proxy: Option<EventLoopProxy<UserEvent>>,
+    error: Option<String>,
+}
+
+impl GuiApp {
+    fn new(initial: Option<InitialSource>, options: Options) -> Self {
+        let (command_tx, command_rx) = mpsc::channel();
+        let (result_tx, result_rx) = mpsc::channel();
+        let worker = std::thread::spawn(move || worker_loop(command_rx, result_tx));
+        Self {
+            initial,
+            model: Model::new(command_tx, result_rx, options),
+            worker: Some(worker),
+            window: None,
+            render: None,
+            proxy: None,
+            error: None,
+        }
+    }
+
+    fn shutdown(&mut self, event_loop: &ActiveEventLoop) {
+        let _ = self.model.commands.send(Command::Shutdown);
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+        self.render = None;
+        self.window = None;
+        event_loop.set_control_flow(ControlFlow::Poll);
+        event_loop.exit();
+    }
+
+    fn fail(&mut self, event_loop: &ActiveEventLoop, message: String) {
+        self.error = Some(message);
+        self.shutdown(event_loop);
+    }
+}
+
+impl Failable for GuiApp {
+    fn take_error(&mut self) -> Option<String> {
+        self.error.take()
+    }
+
+    fn set_event_loop_proxy(&mut self, proxy: EventLoopProxy<UserEvent>) {
+        self.proxy = Some(proxy);
+    }
+}
+
+impl ApplicationHandler<UserEvent> for GuiApp {
+    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        if self.window.is_some() {
+            return;
+        }
+        let attributes = Window::default_attributes()
+            .with_title("eventcv - playback")
+            .with_inner_size(LogicalSize::new(1_100, 720));
+        let window = match event_loop.create_window(attributes) {
+            Ok(window) => Arc::new(window),
+            Err(error) => return self.fail(event_loop, error.to_string()),
+        };
+        let Some(proxy) = self.proxy.clone() else {
+            return self.fail(
+                event_loop,
+                "event loop proxy was not initialised".to_owned(),
+            );
+        };
+        match GuiRender::new(window.clone(), proxy) {
+            Ok(render) => {
+                self.render = Some(render);
+                self.window = Some(window.clone());
+                if let Some(source) = self.initial.take() {
+                    match source {
+                        InitialSource::Recording(source) => self.model.set_initial_source(source),
+                        #[cfg(feature = "camera")]
+                        InitialSource::Live {
+                            pump,
+                            name,
+                            width,
+                            height,
+                        } => self.model.set_live_source(pump, name, width, height),
+                    }
+                }
+                window.request_redraw();
+                event_loop.set_control_flow(ControlFlow::WaitUntil(Instant::now() + ACTIVE_POLL));
+            }
+            Err(error) => self.fail(event_loop, error),
+        }
+    }
+
+    fn window_event(&mut self, event_loop: &ActiveEventLoop, _id: WindowId, event: WindowEvent) {
+        if matches!(event, WindowEvent::CloseRequested) {
+            return self.shutdown(event_loop);
+        }
+        let consumed = match (&mut self.render, &self.window) {
+            (Some(render), Some(window)) => render.state.on_window_event(window, &event).consumed,
+            _ => false,
+        };
+        if !consumed
+            && matches!(
+                &event,
+                WindowEvent::KeyboardInput { event, .. }
+                    if event.state == ElementState::Pressed
+                        && event.logical_key == Key::Named(NamedKey::Escape)
+            )
+        {
+            return self.shutdown(event_loop);
+        }
+        match event {
+            WindowEvent::Resized(size) => {
+                if let Some(render) = &mut self.render {
+                    render.resize(size);
+                }
+                if let Some(window) = &self.window {
+                    window.request_redraw();
+                }
+            }
+            WindowEvent::RedrawRequested => {
+                let result = match (&mut self.render, &self.window) {
+                    (Some(render), Some(window)) => render.draw(window, &mut self.model),
+                    _ => Ok(()),
+                };
+                if let Err(error) = result {
+                    self.fail(event_loop, error);
+                }
+            }
+            _ if !consumed => {
+                if let Some(window) = &self.window {
+                    window.request_redraw();
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn user_event(&mut self, _event_loop: &ActiveEventLoop, event: UserEvent) {
+        let UserEvent::AccessKit(event) = event;
+        if self.window.as_ref().map(|window| window.id()) != Some(event.window_id) {
+            return;
+        }
+        match event.window_event {
+            egui_winit::accesskit_winit::WindowEvent::ActionRequested(request) => {
+                if let Some(render) = &mut self.render {
+                    render.state.on_accesskit_action_request(request);
+                }
+            }
+            egui_winit::accesskit_winit::WindowEvent::InitialTreeRequested => {}
+            egui_winit::accesskit_winit::WindowEvent::AccessibilityDeactivated => {}
+        }
+        if let Some(window) = &self.window {
+            window.request_redraw();
+        }
+    }
+
+    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        let now = Instant::now();
+        let changed = self.model.poll() | self.model.tick(now);
+        if changed {
+            if let Some(window) = &self.window {
+                window.request_redraw();
+            }
+        }
+        let deadline = if self.model.pending || self.model.loading {
+            now + ACTIVE_POLL
+        } else if self.model.playing {
+            self.model.next_due.max(now)
+        } else {
+            now + IDLE_POLL
+        };
+        event_loop.set_control_flow(ControlFlow::WaitUntil(deadline));
+    }
+}
+
+impl Drop for GuiApp {
+    fn drop(&mut self) {
+        let _ = self.model.commands.send(Command::Shutdown);
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+    }
+}
+
+pub(crate) fn run_empty(options: Options) -> Result<(), String> {
+    gpu::run_app(GuiApp::new(None, options))
+}
+
+pub(crate) fn run_reader(
+    reader: Arc<Mutex<Reader>>,
+    ops: SliceOps,
+    hot_pixel_mask: Option<Arc<[bool]>>,
+    options: Options,
+) -> Result<(), String> {
+    let source = PlaybackSource {
+        reader,
+        ops,
+        hot_pixel_mask,
+        name: "recording".to_owned(),
+    };
+    gpu::run_app(GuiApp::new(Some(InitialSource::Recording(source)), options))
+}
+
+pub(crate) fn run_stream(stream: EventStream, options: Options) -> Result<(), String> {
+    let source = PlaybackSource {
+        reader: Arc::new(Mutex::new(Box::new(MemorySliceSource::new(stream)))),
+        ops: crate::no_slice_ops(),
+        hot_pixel_mask: None,
+        name: "in-memory stream".to_owned(),
+    };
+    gpu::run_app(GuiApp::new(Some(InitialSource::Recording(source)), options))
+}
+
+#[cfg(feature = "camera")]
+pub(crate) struct CameraResult {
+    pub(crate) capture: Option<eventcv_core::device::Capture>,
+    pub(crate) recorder: Option<crate::Recorder>,
+    pub(crate) skipped: usize,
+    pub(crate) overflows: usize,
+    pub(crate) result: Result<(), String>,
+}
+
+#[cfg(feature = "camera")]
+pub(crate) fn run_camera(
+    capture: eventcv_core::device::Capture,
+    recorder: Option<crate::Recorder>,
+    options: Options,
+) -> CameraResult {
+    let (width, height) = (capture.width(), capture.height());
+    let name = capture.name().to_owned();
+    let pump = Arc::new(Mutex::new(crate::capture::Pump::start(
+        capture,
+        recorder,
+        crate::capture::Backpressure::Latest,
+    )));
+    let result = gpu::run_app(GuiApp::new(
+        Some(InitialSource::Live {
+            pump: Arc::clone(&pump),
+            name,
+            width,
+            height,
+        }),
+        options,
+    ));
+    let pump = match Arc::try_unwrap(pump) {
+        Ok(pump) => pump,
+        Err(_) => panic!("GUI worker released the camera pump"),
+    };
+    let mut pump = match pump.into_inner() {
+        Ok(pump) => pump,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    let skipped = pump.n_skipped();
+    let overflows = pump.n_overflows();
+    let (capture, recorder) = pump.stop();
+    CameraResult {
+        capture,
+        recorder,
+        skipped,
+        overflows,
+        result,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use eventcv_core::EventStreamBuilder;
+
+    use super::*;
+
+    fn sample(rows: &[(u16, u16, i64, bool)]) -> EventStream {
+        let mut builder = EventStreamBuilder::new(4, 4, 0.001);
+        for &(x, y, t, p) in rows {
+            builder.push(x, y, t, p);
+        }
+        builder.build()
+    }
+
+    fn metadata(duration_us: i64) -> Metadata {
+        Metadata {
+            name: "test".to_owned(),
+            width: 4,
+            height: 4,
+            n_events: 10,
+            start_us: 0,
+            end_us: duration_us,
+            live: false,
+            skipped_windows: 0,
+        }
+    }
+
+    fn model() -> Model {
+        let (commands, _command_rx) = mpsc::channel();
+        let (_result_tx, results) = mpsc::channel();
+        Model::new(commands, results, Options::default())
+    }
+
+    fn worker(stream: EventStream) -> WorkerSource {
+        WorkerSource::new(
+            PlaybackSource {
+                reader: Arc::new(Mutex::new(Box::new(MemorySliceSource::new(stream)))),
+                ops: crate::no_slice_ops(),
+                hot_pixel_mask: None,
+                name: "test".to_owned(),
+            },
+            view_config(),
+        )
+    }
+
+    fn view_config() -> ViewConfig {
+        ViewConfig {
+            repr: None,
+            colormap: Colormap::Viridis,
+            clim: None,
+            decay_ms: Some(1.0),
+        }
+    }
+
+    #[test]
+    fn cursor_is_clamped_to_complete_frame_origins() {
+        assert_eq!(max_cursor_us(95_000, 30_000, 10_000, None), 90_000);
+        assert_eq!(max_cursor_us(95_000, 30_000, 10_000, Some(2)), 10_000);
+        assert_eq!(max_cursor_us(0, 30_000, 10_000, None), 0);
+        assert_eq!(max_cursor_us(10_000, 30_000, 10_000, None), 0);
+        assert_eq!(ms_to_us(0.001), 100);
+        assert_eq!(ms_to_us(2_000.0), 1_000_000);
+    }
+
+    #[test]
+    fn stats_count_both_polarities() {
+        let stats = window_stats(
+            &sample(&[(0, 0, 0, true), (1, 0, 500, false), (2, 0, 900, true)]),
+            1_000,
+        );
+        assert_eq!((stats.total, stats.positive, stats.negative), (3, 2, 1));
+        assert_eq!(stats.rate, 3_000.0);
+    }
+
+    #[test]
+    fn refractory_history_crosses_window_boundary() {
+        let mut processor = RefractoryProcessor::new(1_000);
+        let first = processor.process((0, 1_000), sample(&[(0, 0, 900, true)]));
+        let second = processor.process((1_000, 2_000), sample(&[(0, 0, 1_100, true)]));
+        assert_eq!(first.len(), 1);
+        assert!(second.is_empty());
+    }
+
+    #[test]
+    fn ordered_pipeline_matches_explicit_filter_composition() {
+        let input = sample(&[
+            (0, 0, 0, true),
+            (1, 0, 100, true),
+            (1, 0, 150, false),
+            (2, 0, 200, true),
+        ]);
+        let config = [
+            ProcessorConfig {
+                plugin: &PROCESSOR_PLUGINS[0],
+                enabled: true,
+                dt_us: 250,
+            },
+            ProcessorConfig {
+                plugin: &PROCESSOR_PLUGINS[1],
+                enabled: true,
+                dt_us: 100,
+            },
+        ];
+        let expected = input.background_activity_filter(250).refractory_filter(100);
+        let actual = Pipeline::new(&config).process((0, 1_000), input.clone());
+        assert_eq!(actual.ts(), expected.ts());
+        assert_eq!(actual.xs(), expected.xs());
+        let (raw, processed) = (window_stats(&input, 1_000), window_stats(&actual, 1_000));
+        assert_eq!(raw.total, input.len() as u64);
+        assert_eq!(processed.total, actual.len() as u64);
+        assert!(processed.total <= raw.total);
+    }
+
+    #[test]
+    fn sliding_window_keeps_overlap_and_processes_only_the_tail() {
+        let recording = sample(&[
+            (0, 0, 100, true),
+            (1, 0, 600, true),
+            (2, 0, 900, false),
+            (3, 0, 1_100, true),
+            (0, 1, 1_400, false),
+        ]);
+        let request = |cursor_us, discontinuous| RenderRequest {
+            generation: 0,
+            cursor_us,
+            dt_us: 1_000,
+            index: (cursor_us / 500) as usize,
+            processors: Vec::new(),
+            discontinuous,
+        };
+        let mut sliding = worker(recording.clone());
+        sliding.render(&request(0, true)).unwrap();
+        let actual = sliding.render(&request(500, false)).unwrap();
+        let expected = worker(recording).render(&request(500, true)).unwrap();
+
+        assert_eq!(actual.raw.total, 4);
+        assert_eq!(actual.raw.total, expected.raw.total);
+        assert_eq!(
+            sliding.raw_window.as_ref().unwrap().ts(),
+            &[600, 900, 1_100, 1_400]
+        );
+        assert_eq!(sliding.last_start_us, Some(600));
+    }
+
+    #[test]
+    fn refresh_rate_sets_a_smaller_sliding_stride_than_accumulation() {
+        let mut player = model();
+        assert_eq!(player.dt_us, 30_000);
+        assert_eq!(player.step_us(), 16_667);
+        player.speed = 2.0;
+        assert_eq!(player.step_us(), 33_333);
+        player.refresh_hz = 120.0;
+        assert_eq!(player.step_us(), 16_667);
+    }
+
+    #[test]
+    fn seek_preroll_matches_uninterrupted_processing() {
+        let recording = sample(&[(0, 0, 900, true), (0, 0, 1_100, true)]);
+        let config = [ProcessorConfig {
+            plugin: &PROCESSOR_PLUGINS[1],
+            enabled: true,
+            dt_us: 1_000,
+        }];
+        let mut uninterrupted = Pipeline::new(&config);
+        let _ = uninterrupted.process((0, 1_000), recording.time_window(0, 1_000));
+        let expected = uninterrupted.process((1_000, 2_000), recording.time_window(1_000, 2_000));
+
+        let mut after_seek = Pipeline::new(&config);
+        let lookback = after_seek.lookback_us();
+        let _ = after_seek.process(
+            (1_000 - lookback, 1_000),
+            recording.time_window(1_000 - lookback, 1_000),
+        );
+        let actual = after_seek.process((1_000, 2_000), recording.time_window(1_000, 2_000));
+        assert_eq!(actual.ts(), expected.ts());
+    }
+
+    #[test]
+    fn seek_preroll_matches_uninterrupted_raw_rendering() {
+        let recording = sample(&[(0, 0, 0, true), (1, 0, 900, false), (2, 0, 1_100, true)]);
+        let request = |cursor_us, discontinuous| RenderRequest {
+            generation: 0,
+            cursor_us,
+            dt_us: 1_000,
+            index: (cursor_us / 1_000) as usize,
+            processors: Vec::new(),
+            discontinuous,
+        };
+
+        let mut uninterrupted = worker(recording.clone());
+        let _ = uninterrupted.render(&request(0, true)).unwrap();
+        let expected = uninterrupted.render(&request(1_000, false)).unwrap();
+        let actual = worker(recording).render(&request(1_000, true)).unwrap();
+        assert_eq!(actual.image, expected.image);
+    }
+
+    #[test]
+    fn failed_replacement_keeps_the_current_source() {
+        let recording = sample(&[(0, 0, 0, true), (1, 0, 900, false)]);
+        let source = PlaybackSource {
+            reader: Arc::new(Mutex::new(Box::new(MemorySliceSource::new(recording)))),
+            ops: crate::no_slice_ops(),
+            hot_pixel_mask: None,
+            name: "test".to_owned(),
+        };
+        let (command_tx, command_rx) = mpsc::channel();
+        let (result_tx, result_rx) = mpsc::channel();
+        let thread = std::thread::spawn(move || worker_loop(command_rx, result_tx));
+        command_tx
+            .send(Command::SetSource {
+                generation: 1,
+                source,
+                view: view_config(),
+            })
+            .unwrap();
+        assert!(matches!(
+            result_rx.recv().unwrap(),
+            ResultMessage::Loaded { .. }
+        ));
+        command_tx
+            .send(Command::Open {
+                generation: 2,
+                path: PathBuf::from("/eventcv/does-not-exist.npz"),
+                view: view_config(),
+            })
+            .unwrap();
+        assert!(matches!(
+            result_rx.recv().unwrap(),
+            ResultMessage::Error { .. }
+        ));
+        command_tx
+            .send(Command::Render(RenderRequest {
+                generation: 3,
+                cursor_us: 0,
+                dt_us: 1_000,
+                index: 0,
+                processors: Vec::new(),
+                discontinuous: true,
+            }))
+            .unwrap();
+        assert!(matches!(result_rx.recv().unwrap(), ResultMessage::Frame(_)));
+        command_tx.send(Command::Shutdown).unwrap();
+        thread.join().unwrap();
+    }
+
+    #[test]
+    fn playback_stops_at_end_and_loop_restarts() {
+        let mut player = model();
+        player.metadata = Some(metadata(95_000));
+        player.cursor_us = player.max_cursor_us();
+        player.playing = true;
+        player.next_due = Instant::now();
+        assert!(player.tick(Instant::now()));
+        assert!(!player.playing);
+
+        player.loop_ = true;
+        player.playing = true;
+        player.pending = false;
+        assert!(player.tick(Instant::now()));
+        assert_eq!(player.cursor_us, 0);
+        assert!(player.pending);
+    }
+
+    #[test]
+    fn stepping_clamps_and_history_resets() {
+        let mut player = model();
+        player.metadata = Some(metadata(95_000));
+        player.push_history(10.0, 5.0);
+        player.step(-1);
+        assert_eq!(player.cursor_us, 0);
+        assert!(player.history.is_empty());
+        player.cursor_us = player.max_cursor_us();
+        player.step(1);
+        assert_eq!(player.cursor_us, player.max_cursor_us());
+    }
+
+    #[test]
+    fn stale_frames_are_ignored_and_history_is_bounded() {
+        let (commands, _command_rx) = mpsc::channel();
+        let (result_tx, results) = mpsc::channel();
+        let mut player = Model::new(commands, results, Options::default());
+        player.generation = 2;
+        for generation in [1, 2] {
+            result_tx
+                .send(ResultMessage::Frame(FrameResult {
+                    generation,
+                    cursor_us: generation as i64 * 1_000,
+                    image: Some(Rgb8Image {
+                        width: 1,
+                        height: 1,
+                        pixels: vec![0, 0, 0],
+                    }),
+                    raw: WindowStats::default(),
+                    processed: WindowStats::default(),
+                    metadata: None,
+                }))
+                .unwrap();
+        }
+        assert!(player.poll());
+        assert_eq!(player.cursor_us, 2_000);
+        assert_eq!(player.history.len(), 1);
+
+        for value in 0..=HISTORY_LIMIT {
+            player.push_history(value as f64, 0.0);
+        }
+        assert_eq!(player.history.len(), HISTORY_LIMIT);
+        assert_eq!(player.history.front().unwrap().raw, 1.0);
+    }
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -40,7 +40,7 @@ Where representations and the simulator run. The CPU is the default and the refe
 .. autofunction:: save_video
 ```
 
-See :doc:`video` for the raw view, and how ``dt_ms`` and ``fps`` combine into playback speed.
+See :doc:`video` for the raw view and the interactive player's controls.
 
 ## Simulation and reconstruction
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -83,17 +83,20 @@ Useful flags:
 ## `eventcv play`
 
 ```console
+$ eventcv play
 $ eventcv play recording.h5 --dt-ms 5
 ```
 
-Opens an interactive window and plays the recording — the offline twin of a camera's live view, and
-raw by default for the same reason `render` is. It blocks until the window is closed (`Esc` or the
-close button).
+Opens the interactive player, empty when no recording is supplied. A file can also be opened from
+the window or dropped onto it. The view is raw by default for the same reason `render` is.
 
-Takes `--dt-ms`, `--fps`, `--repr`, `--decay-ms` and `--colormap` exactly as `render` does, plus:
+At `--speed 1`, recording time matches wall time. `--fps` is accepted only for compatibility and
+is deprecated. The player also takes `--dt-ms`, `--refresh-hz`, `--repr`, `--decay-ms`,
+`--colormap`, and `--clim`.
 
 - `--speed` — playback rate multiplier; `--speed 0.25` for a slow look at a fast scene.
-- `--loop` — restart at the end instead of closing.
+- `--refresh-hz` — sliding-window refresh cap; defaults to 60 Hz independently of `--dt-ms`.
+- `--loop` — restart at the end instead of pausing on the final frame.
 
 ## `eventcv simulate`
 

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -104,8 +104,9 @@ npz and rosbag both have something to write at the end — a header stating the 
 index — so they spill to a scratch file beside the target while the capture runs and assemble it on
 close. Pick one of the others for a session you might have to kill.
 
-Only windows that are actually **read** are recorded, since `show()` doesn't poll them. To record
-without a loop, use {func}`~eventcv.record`, which opens the camera, captures, and closes it:
+Iteration and the event GUI archive every decoded window before display backpressure is applied.
+To record without a loop or window, use {func}`~eventcv.record`, which opens the camera, captures,
+and closes it:
 
 ```python
 ecv.record("session.h5", seconds=10)     # blocks 10 s (or Ctrl+C); returns the event count
@@ -158,9 +159,9 @@ driver's ring drains continuously whatever your loop is doing, and the loop only
 that are already decoded — so the per-window budget is yours to spend. On an EVK4 at `dt_ms=50`,
 40 ms of processing per frame still holds 19.9 of an ideal 20 fps with the ring empty.
 
-{meth}`~eventcv.EventCamera.show`, {meth}`~eventcv.EventCamera.record`, and
-{meth}`~eventcv.EventCamera.close` pause the thread to take the camera back; it restarts on the next
-read.
+The event GUI uses the same pump. {meth}`~eventcv.EventCamera.record`, APS viewing,
+{meth}`~eventcv.EventCamera.draw_mask`, and {meth}`~eventcv.EventCamera.close` take the camera back
+directly; normal reads restart the pump when needed.
 
 Four counters tell you what the pipeline is doing:
 
@@ -289,10 +290,13 @@ to render that instead:
 
 ```python
 ecv.stream().show()                     # raw polarity view (the default)
-ecv.stream(dt_ms=30).show("count")      # a representation, colour-mapped
+ecv.stream(dt_ms=30).show("count", refresh_hz=60)
 ```
 
-It blocks on the main thread until the window closes, then the camera is usable again.
+The same accumulation, refresh-rate, statistics, and ordered processor controls used for recordings
+work live. Capture and `record=` continue while display is paused; the source panel reports windows
+the freshness queue skipped. It blocks on the main thread until the window closes, then the camera
+is usable again. `show("aps")` keeps the specialized APS viewer.
 
 ## Reference
 

--- a/docs/video.md
+++ b/docs/video.md
@@ -114,16 +114,19 @@ into a paper — use {func}`eventcv.export_png`.
 {meth}`~eventcv.EventCamera.show`, and the same raw polarity-and-decay view by default:
 
 ```python
+ecv.play()                                             # open empty, then choose or drop a file
 ecv.play("recording.h5", dt_ms=5)                    # raw
 ecv.play("recording.h5", dt_ms=20, repr="count")     # a representation
 ecv.play(events, speed=0.25)                         # an in-memory stream, quarter speed
 ```
 
-It blocks on the main thread until the window is closed (`Esc` or the close button). `speed`
-multiplies the playback rate and `loop_=True` restarts at the end instead of closing. Frames are
-decoded and rendered as they are shown, so a file larger than memory plays without being loaded —
-and unlike the live camera viewer, nothing is dropped to keep up: a slow decode plays slower rather
-than skipping events, because a file has no ring buffer to overflow.
+The window provides play/pause, stepping, seeking, accumulation time, refresh rate, loop and speed
+controls, raw/processed statistics, and an ordered denoising pipeline. Accumulation and refresh are
+independent: the default 30 ms window advances about every 16.7 ms at 60 Hz, retaining the overlap
+and processing only its new tail. At `speed=1`, recording time matches wall time; explicit `fps=`
+keeps the old fixed-frame-rate calculation but is deprecated. One render is kept in flight, so a
+file larger than memory stays lazy and slow processing lowers playback speed instead of building a
+work queue.
 
 A single still image of the raw view, without a window:
 
@@ -135,6 +138,7 @@ events.view("raw")                      # or show it
 From the command line:
 
 ```console
+$ eventcv play
 $ eventcv play recording.h5 --dt-ms 5
 $ eventcv play recording.h5 --dt-ms 5 --speed 0.25 --loop
 ```

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,0 +1,2431 @@
+version: 7
+platforms:
+- name: linux-64
+  virtual-packages:
+  - __unix=0=0
+  - __linux=4.18
+  - __glibc=2.28
+  - __archspec=0=x86_64
+- name: linux-aarch64
+  virtual-packages:
+  - __unix=0=0
+  - __linux=4.18
+  - __glibc=2.28
+  - __archspec=0=aarch64
+- name: osx-arm64
+  virtual-packages:
+  - __unix=0=0
+  - __osx=13.0
+  - __archspec=0=m1
+- name: win-64
+  virtual-packages:
+  - __win=10.0
+  - __archspec=0=x86_64
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    indexes:
+    - https://pypi.org/simple
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.46.1-default_hfdba357_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-h280c20c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cmake-4.4.2-hff7ac6b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-16.1.0-h5fcb69b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-h7cc23a3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbc21106_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-heca4667_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h373387f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.1.0-he0feb66_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpsl-0.23.1-hd9e3e90_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-16.1.0-hf2715c6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-hf4e2dac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-h6154650_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/maturin-1.14.1-py310h67c5e53_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/onnxruntime-cpp-1.28.0-hc421db2_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.6-h242f9ac_102_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rhash-1.4.6-hb03c661_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rust-1.97.1-h53717f1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-16.1.0-h59071f9_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-16.1.0-h41cdd0d_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.2.1-pyh145f28c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-unknown-linux-gnu-1.97.1-h2c6d0dc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+      - pypi: https://files.pythonhosted.org/packages/c7/99/461bd36dbdfac6c1c53efa370bd55a83227542d0d118f1677dbf1a3dacd5/numpy-2.5.2-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      linux-aarch64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.46.1-default_h5f4c503_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.8-h80f16a2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cmake-4.4.2-hcbeb305_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-16.1.0-h04da0f0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-py311h3512406_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.3-h5bc82ec_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.22.2-h095d8e5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.46.1-default_h1979696_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.21.0-h23397ac_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20250104-pl5321hc48eb74_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h80f16a2_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.8.1-hfae3067_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.7.0-h376a255_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-16.1.0-h205dda4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-16.1.0-h8acb6b2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-5.8.3-he30d5cf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libmpdec-4.0.0-he30d5cf_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.68.1-hd3077d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpsl-0.23.1-hb8431ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-16.1.0-h2510bd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.53.4-h022381a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.1-h7572e3e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-16.1.0-hef695bb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.42.2-h1022ec0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuv-1.52.1-h80f16a2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.2-hdc9db2a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/maturin-1.14.1-py310hf87f8eb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.6-h2b6f883_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/onnxruntime-cpp-1.28.0-h106f1d4_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.6.3-h546c87b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.14.6-h1a34557_102_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rhash-1.4.6-he30d5cf_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rust-1.97.1-h6cf38e9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_h5cf4473_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-h9d15635_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-16.1.0-hd673532_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-16.1.0-h2445e1f_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.2.1-pyh145f28c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-unknown-linux-gnu-1.97.1-hbe8e118_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.28-h585391f_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+      - pypi: https://files.pythonhosted.org/packages/c4/3b/ecd49dd90033cceb2704d88ca905d4d7d89b0e8c739608754ffd325fa820/numpy-2.5.2-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.2.1-pyh145f28c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-apple-darwin-1.97.1-hf6ec828_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h4e30115_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.8-h1a92334_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cmake-4.4.2-hf91ab31_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-py310h579977c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-h34f8a20_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.21.0-hf618e03_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321h26f1114_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h1a92334_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-hcf2aa1b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.68.1-h8f3e76b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpsl-0.23.1-hdb0c161_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.4-h1ae2325_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.1-hbf2880b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.52.1-h1a92334_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/maturin-1.14.1-py310h277814e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/onnxruntime-cpp-1.28.0-h3a32141_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.6-hf4d206d_102_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rhash-1.4.6-h84a0fba_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rust-1.97.1-h4ff7c5d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hd3d0363_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hf451053_7.conda
+      - pypi: https://files.pythonhosted.org/packages/17/e1/2c1d4b1987795a92b5bbf7c24fe249ab96aa2573ab0d7604802c189d7b86/numpy-2.5.2-cp314-cp314-macosx_11_0_arm64.whl
+      win-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-h4c7d964_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.2.1-pyh145f28c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-pc-windows-msvc-1.97.1-h17fc481_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cmake-4.4.2-hde52c71_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/icu-78.3-h5112557_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.22.2-h719d79b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.21.0-hdb0ef4a_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.7.0-h3d046cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.3-hfd05255_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libmpdec-4.0.0-hfd05255_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpsl-0.23.1-h9b16d47_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.53.4-hf5d6505_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.1-h734d217_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libuv-1.52.1-h6a83c73_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.2-hfd05255_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/maturin-1.14.1-py310h3ce4601_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/onnxruntime-cpp-1.28.0-h50ebc8d_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.6.3-hf411b9b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.14.6-h53f6dd8_102_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/rust-1.97.1-hf8d6059_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h967ab96_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-ha367084_41.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36247-habf1de7_41.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36247-habf1de7_41.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_7.conda
+      - pypi: https://files.pythonhosted.org/packages/15/5c/7bcbd5b11f94199073320410cddcbb80cee62415bfeb540874b265c2d922/numpy-2.5.2-cp314-cp314-win_amd64.whl
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+  build_number: 20
+  sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
+  md5: a9f577daf3de00bca7c3c76c0ecbd1de
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl <0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    strong:
+    - _openmp_mutex >=4.5
+  size: 28948
+  timestamp: 1770939786096
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.46.1-default_hfdba357_102.conda
+  sha256: fb7bf36984a37ce7e4714d1d1da0bd0e3bfc679520f5cdc184afc676fd4b5da2
+  md5: a0c5e0b7f58c8ceeb08e5bc41251d5a2
+  depends:
+  - ld_impl_linux-64 2.46.1 default_hbd61a6d_102
+  - sysroot_linux-64
+  - zstd >=1.5.7,<1.6.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 3713752
+  timestamp: 1784214522814
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+  sha256: 1a0d382c515ebf55f8ee1f38c8b81bc95af5c2acc42ad53b66bc5df932032f96
+  md5: e675fabcf81499adc7edf58124fb1e01
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: bzip2-1.0.6
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - bzip2 >=1.0.8,<2.0a0
+  size: 257808
+  timestamp: 1785906269155
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-h280c20c_1.conda
+  sha256: 5139b6afbfaca91c47104ba9a6a40f81211e1c9200e96b73ce3a56f0ca1902f4
+  md5: 2cef891b791040aab83e218c7d137679
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - c-ares-static <0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - c-ares >=1.34.8,<2.0a0
+  size: 226755
+  timestamp: 1786116641939
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cmake-4.4.2-hff7ac6b_1.conda
+  sha256: 70dbc951e5151a0fcf670a482dd69b43ac0999331b17a3bf99acaa4faac1e0c2
+  md5: 21e00b3310f6fac45de4983f6f7bbdae
+  depends:
+  - libgcc >=15
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=15
+  - liblzma >=5.8.3,<6.0a0
+  - rhash >=1.4.6,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libuv >=1.52.1,<2.0a0
+  - libcurl >=8.21.0,<9.0a0
+  - ncurses >=6.6,<7.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports: {}
+  size: 26073838
+  timestamp: 1786961015774
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-16.1.0-h5fcb69b_1.conda
+  sha256: 00c87015522248adb5565a1b8f977cfe927831dd7ef0cb0a5d13f896844af719
+  md5: 419982d8913246db404319048e062d3e
+  depends:
+  - binutils_impl_linux-64 >=2.46.1
+  - libgcc >=16.1.0
+  - libgcc-devel_linux-64 16.1.0 h59071f9_101
+  - libgomp >=16.1.0
+  - libsanitizer 16.1.0 hf2715c6_1
+  - libstdcxx >=16.1.0
+  - libstdcxx-devel_linux-64 16.1.0 h41cdd0d_101
+  - sysroot_linux-64
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 85161422
+  timestamp: 1785375529345
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
+  sha256: 9f07834f0c546ab14d885ce0366285f61f44e326c0edd1fc63b8294e113ae432
+  md5: 72a381cbad04f24b1c2a43ef707f45b4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - icu >=78.3,<79.0a0
+  size: 14459115
+  timestamp: 1786545741408
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-h7cc23a3_1.conda
+  sha256: dd053c96dcb0dcfd59422aefea9d2fe937a190167f34fba7893ec1e10a7e8963
+  md5: ba55d1b89fd7775e67de8291029b4059
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  license: LGPL-2.1-or-later
+  purls: []
+  run_exports:
+    weak:
+    - keyutils >=1.6.3,<2.0a0
+  size: 135295
+  timestamp: 1786739238128
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbc21106_2.conda
+  sha256: 2a5c38c85e63df84c4e69ee71439841ce570d259ae3060627bb9a49a938d66f4
+  md5: 53318d715316929a574f83591308b1f8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - keyutils >=1.6.3,<2.0a0
+  - libedit >=3.1.20250104,<3.2.0a0
+  - libedit >=3.1.20250104,<4.0a0
+  - libgcc >=15
+  - libstdcxx >=15
+  - openssl >=3.5.7,<4.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - krb5 >=1.22.2,<1.23.0a0
+  size: 1394333
+  timestamp: 1786762112514
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+  sha256: 27d83f1188cd19bcb7754a078b3fa7f4cfb8527f8eb2fde54dd01fc529d1adec
+  md5: 449500f2c089da11c40f5c21312e3e07
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - zstd >=1.5.7,<1.6.0a0
+  constrains:
+  - binutils_impl_linux-64 2.46.1
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 745303
+  timestamp: 1784214507189
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-heca4667_4.conda
+  sha256: aff8ef75636d0825ce34911e0bef2f26816e7afd090a9dcb4b9bacab75cbf584
+  md5: 3f2fd5617cfacac49c85f6dc63842ea1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.22.2,<1.23.0a0
+  - libgcc >=14
+  - libnghttp2 >=1.68.1,<2.0a0
+  - libpsl >=0.23.0,<0.24.0a0
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.7,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: curl
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libcurl >=8.21.0,<9.0a0
+  size: 480565
+  timestamp: 1785500108494
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h373387f_1.conda
+  sha256: 6473eb8caf2aae830f37caa93db9b26dddf7ac84b63229e8bf7fc0e5c3ab95b0
+  md5: 50708d3b951d0f8e2d7f2df5b5edc040
+  depends:
+  - ncurses
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ncurses >=6.6,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - libedit >=3.1.20250104,<3.2.0a0
+  size: 135098
+  timestamp: 1786616658086
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
+  sha256: e4418f68d01a6307c4431b585c71b584f40189877364e542ee87deb777f5e85b
+  md5: 7bc31538d6e3fb349e897353969237ec
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: BSD-2-Clause OR GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  run_exports:
+    weak:
+    - libev >=4.33,<4.34.0a0
+  size: 43220
+  timestamp: 1785917328200
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+  sha256: 16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
+  md5: b24d3c612f71e7aa74158d92106318b2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - expat 2.8.1.*
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports: {}
+  size: 77856
+  timestamp: 1781203599810
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
+  sha256: ac38603008bf1e99b8ed379b1a656a67a70e2841f2b6a069c630cdf6316012d2
+  md5: 0abe40a9880086ca4d2e5daf09dceff9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libffi >=3.7.0,<3.8.0a0
+  size: 67576
+  timestamp: 1783520858222
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_1.conda
+  sha256: d5cb8475131c31680f8fd30512c418f373064e272e452063276a8fb14c9fa42f
+  md5: 5a7d954665c707c93311657cd779c705
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgomp 16.1.0 he0feb66_1
+  - libgcc-ng ==16.1.0=*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 1057877
+  timestamp: 1785375436766
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.1.0-he0feb66_1.conda
+  sha256: 62cb599ad0539d99386515326d9d5e8f51f75a60c69c2131b21df76edf35bd89
+  md5: 88f2d91cb1533194c323534253094d23
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports:
+    strong:
+    - _openmp_mutex >=4.5
+  size: 640415
+  timestamp: 1785375373755
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+  sha256: 9787df8c22a59c9a70d3e5a10db9ad663485e75e9ccc3f09bd092cb7b95e0dab
+  md5: 1390b7c5ac0b1d8e447bc5efa6d3c8c2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - xz 5.8.3.*
+  license: 0BSD
+  purls: []
+  run_exports:
+    weak:
+    - liblzma >=5.8.3,<6.0a0
+  size: 112995
+  timestamp: 1786348617826
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_2.conda
+  sha256: 46820b4a835e175940ae20bec00fdddaff804cda27a1408ab1b95e77a2196437
+  md5: fcfed1dc5053eb1901b66e7b1fc32588
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  run_exports: {}
+  size: 92759
+  timestamp: 1786650399772
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+  sha256: 663444d77a42f2265f54fb8b48c5450bfff4388d9c0f8253dd7855f0d993153f
+  md5: 2a45e7f8af083626f009645a6481f12d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - c-ares >=1.34.6,<2.0a0
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.5,<4.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libnghttp2 >=1.68.1,<2.0a0
+  size: 663344
+  timestamp: 1773854035739
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpsl-0.23.1-hd9e3e90_1.conda
+  sha256: 09e8effdc89bc5d021349318d32b85594f5b8d8e3ab8f90a85b81f8fe695a566
+  md5: 77be60417aa572afcb48cbe0f967401d
+  depends:
+  - libstdcxx >=15
+  - libgcc >=15
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.3,<79.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libpsl >=0.23.1,<0.24.0a0
+  size: 72519
+  timestamp: 1786970753847
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-16.1.0-hf2715c6_1.conda
+  sha256: 85662ecadd3961bc96cbcc38dbc024a768cc35932c8440677ed028ea6322c36c
+  md5: abd77210925872ee084672cf5be1d491
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=16.1.0
+  - libstdcxx >=16.1.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports:
+    weak:
+    - libsanitizer 16.1.0
+  size: 7780843
+  timestamp: 1785375481116
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-hf4e2dac_0.conda
+  sha256: 72023efc207fe681e26b65fc9d668062cf0b4f0eacf3431e6eb099b95c1f2efd
+  md5: df088a279cd5e6fd2790b4c196434da1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.3,<79.0a0
+  - libgcc >=14
+  - libzlib >=1.3.2,<2.0a0
+  license: blessing
+  purls: []
+  run_exports:
+    weak:
+    - libsqlite >=3.53.4,<4.0a0
+  size: 964200
+  timestamp: 1785016112246
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-h6154650_1.conda
+  sha256: 7e463000fa1cba3f3a6597b776f6ab301d425a96e3bc20d0d9d76a3b9f237aa3
+  md5: 5c526561e1d2a2e071941174eae84557
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.7,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - libssh2 >=1.11.1,<2.0a0
+  size: 306045
+  timestamp: 1786713107897
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_1.conda
+  sha256: 79721dd08aeb0ab9e773f1f9ef41cf4e6c17477e3d72319147619045bce05a09
+  md5: aed6cf89adc1e9b846e4367ac538e434
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc 16.1.0 ha9f2e26_1
+  constrains:
+  - libstdcxx-ng ==16.1.0=*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 6631744
+  timestamp: 1785375462643
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+  sha256: 9b1bdce27a7e31f7d241aeecff67a1f3101d52a2b1e33ccc2cdf2613072bf81f
+  md5: 01bb81d12c957de066ea7362007df642
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - libuuid >=2.42.2,<3.0a0
+  size: 40017
+  timestamp: 1781625522462
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_1.conda
+  sha256: 67761d0206f84140047a367eaf9befe03a7e157a29ee25aee0047b40801cc6b6
+  md5: 01c4ed87826af55996768af6dbc936b4
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libuv >=1.52.1,<2.0a0
+  size: 420040
+  timestamp: 1785914567661
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+  sha256: eb8a0db0aa570124f7d2a93d7c7f596e3390df5e047818d873baad32985fc736
+  md5: 0de0122d9570a8ab637c6b73db268389
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - zlib 1.3.2 *_3
+  license: Zlib
+  license_family: Other
+  purls: []
+  run_exports:
+    weak:
+    - libzlib >=1.3.2,<2.0a0
+  size: 63713
+  timestamp: 1785362952714
+- conda: https://conda.anaconda.org/conda-forge/linux-64/maturin-1.14.1-py310h67c5e53_2.conda
+  noarch: python
+  sha256: 420dd288ed066282e43b876629a02e512e269ed1a775991b37ee5701b60fac52
+  md5: f9eb7b3aa6ded33bcc9801fc19abefe8
+  depends:
+  - python
+  - tomli >=1.1.0
+  - libgcc >=15
+  - __glibc >=2.17,<3.0.a0
+  - openssl >=3.5.7,<4.0a0
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/maturin?source=compressed-mapping
+  run_exports: {}
+  size: 9539973
+  timestamp: 1786670703157
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+  sha256: 5d46557214ed184381dafe835b7c94a474a1c3b307a08a250b1ea4779b44ffb3
+  md5: ee6c0cd80a60961a1f48aa3e0b91f986
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: X11 AND BSD-3-Clause
+  purls: []
+  run_exports:
+    weak:
+    - ncurses >=6.6,<7.0a0
+  size: 911196
+  timestamp: 1786355078102
+- conda: https://conda.anaconda.org/conda-forge/linux-64/onnxruntime-cpp-1.28.0-hc421db2_0_cpu.conda
+  sha256: 28b6837ef9d47e84ddeca675e32fd8ac5514005ea7e5b61733d656b670efb7eb
+  md5: be7b47167e18da9fb53bf91982af4c91
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT AND BSL-1.0
+  purls: []
+  run_exports:
+    weak:
+    - onnxruntime-cpp >=1.28.0,<1.28.1.0a0
+  size: 21642054
+  timestamp: 1786188410819
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_1.conda
+  sha256: 012096056b97abf1f68c46b7146bd2cbd68c1be762340b4f5dad4fbbe99177bc
+  md5: c5955c27917ff2234def47f075e71e02
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - ca-certificates
+  - libgcc >=14
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  run_exports:
+    weak:
+    - openssl >=3.6.3,<4.0a0
+  size: 3182423
+  timestamp: 1785913583650
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.6-h242f9ac_102_cp314.conda
+  build_number: 102
+  sha256: f5ff5c1fac471dfed4fc4288856a63eb9d771e6042d9f70420d75b9f488400d8
+  md5: 9b6c336ef7195fbee1c10c09bfcf901b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.8.1,<3.0a0
+  - libffi >=3.7.0,<3.8.0a0
+  - libgcc >=14
+  - liblzma >=5.8.3,<6.0a0
+  - libmpdec >=4.0.0,<5.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - libuuid >=2.42.2,<3.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - ncurses >=6.6,<7.0a0
+  - openssl >=3.5.7,<4.0a0
+  - python_abi 3.14.* *_cp314
+  - readline >=8.3,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - zstd >=1.5.7,<1.6.0a0
+  license: Python-2.0
+  purls: []
+  run_exports:
+    weak:
+    - python_abi 3.14.* *_cp314
+    noarch:
+    - python
+  size: 36866750
+  timestamp: 1786444737142
+  python_site_packages_path: lib/python3.14/site-packages
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+  sha256: 12ffde5a6f958e285aa22c191ca01bbd3d6e710aa852e00618fa6ddc59149002
+  md5: d7d95fc8287ea7bf33e0e7116d2b95ec
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  run_exports:
+    weak:
+    - readline >=8.3,<9.0a0
+  size: 345073
+  timestamp: 1765813471974
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rhash-1.4.6-hb03c661_2.conda
+  sha256: 186a5b225077ad5f4656966da947d43307101950751ef4a239b455588756b4e1
+  md5: 007602d697e07c11ff9864964eba5ee3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - rhash >=1.4.6,<2.0a0
+  size: 194994
+  timestamp: 1786731436520
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rust-1.97.1-h53717f1_1.conda
+  sha256: cb56b3177657b4446b60c3d20d7976198c84abafb0f44a877166eec14c91e2f0
+  md5: cffa2c51d39eed4307335ce32c9c5a4f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - gcc_impl_linux-64
+  - libgcc >=14
+  - libzlib >=1.3.2,<2.0a0
+  - rust-std-x86_64-unknown-linux-gnu 1.97.1 h2c6d0dc_1
+  - sysroot_linux-64 >=2.17
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    strong_constrains:
+    - __glibc >=2.17
+  size: 173878988
+  timestamp: 1786462553726
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
+  build_number: 103
+  sha256: 43624eab22f5f29df7d6ffe914cf442f28fd559b55b290906255492826e636e8
+  md5: 48a1049e710857572fc2a832aa394d9f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libzlib >=1.3.2,<2.0a0
+  constrains:
+  - xorg-libx11 >=1.8.13,<2.0a0
+  license: TCL
+  purls: []
+  run_exports:
+    weak:
+    - tk >=8.6.13,<8.7.0a0
+  size: 3550916
+  timestamp: 1784229071544
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
+  sha256: 47d682b9f6d6ec9eb1a6e6c3e75ea6273e899e78fb7fc59f81d39745009fbc60
+  md5: aa459086047c0e5e27023ab19f8cb86a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - zstd >=1.5.7,<1.6.0a0
+  size: 601301
+  timestamp: 1786599621503
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
+  build_number: 20
+  sha256: a2527b1d81792a0ccd2c05850960df119c2b6d8f5fdec97f2db7d25dc23b1068
+  md5: 468fd3bb9e1f671d36c2cbc677e56f1d
+  depends:
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl <0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    strong:
+    - _openmp_mutex >=4.5
+  size: 28926
+  timestamp: 1770939656741
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.46.1-default_h5f4c503_102.conda
+  sha256: eebe159bf600943552e4319ff4ce27b6a2dadf0dcc5443e76dcee9259a408e11
+  md5: 58f37d76b8234c69dbf2939d511bea0b
+  depends:
+  - ld_impl_linux-aarch64 2.46.1 default_h1979696_102
+  - sysroot_linux-aarch64
+  - zstd >=1.5.7,<1.6.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 4677171
+  timestamp: 1784214549910
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_10.conda
+  sha256: 24eacc8a20fd7c4616566178562bef7f9344eb4a8700cfc3180fa75a6ff9d39f
+  md5: fd544ef1c672d645bf78e5819cbb8f91
+  depends:
+  - libgcc >=14
+  license: bzip2-1.0.6
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - bzip2 >=1.0.8,<2.0a0
+  size: 194694
+  timestamp: 1785906301397
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.8-h80f16a2_1.conda
+  sha256: 537be62d1835ba3d211941537a13302f6c827d9b1316ca11384c0f47ca755cc8
+  md5: 9aaa63e98eb2cf6d22d1d2f87ec9adba
+  depends:
+  - libgcc >=14
+  constrains:
+  - c-ares-static <0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - c-ares >=1.34.8,<2.0a0
+  size: 236990
+  timestamp: 1786116643290
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cmake-4.4.2-hcbeb305_1.conda
+  sha256: cb37d4c4f3fc0a9618583d33b0c6357e8e9ed8ccbca0cd2524047f6f870d9427
+  md5: df0d83dcddb5b508fc989d5572d96c31
+  depends:
+  - libgcc >=15
+  - libstdcxx >=15
+  - libexpat >=2.8.1,<3.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libuv >=1.52.1,<2.0a0
+  - ncurses >=6.6,<7.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libcurl >=8.21.0,<9.0a0
+  - rhash >=1.4.6,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports: {}
+  size: 25498386
+  timestamp: 1786961020891
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-16.1.0-h04da0f0_1.conda
+  sha256: ad024e118ed57e7277547fd03a913b981e9bb9a6db258b8943293b13329d4489
+  md5: e5551bb5b75bcc4031e40f2b69baab84
+  depends:
+  - binutils_impl_linux-aarch64 >=2.46.1
+  - libgcc >=16.1.0
+  - libgcc-devel_linux-aarch64 16.1.0 hd673532_101
+  - libgomp >=16.1.0
+  - libsanitizer 16.1.0 h2510bd8_1
+  - libstdcxx >=16.1.0
+  - libstdcxx-devel_linux-aarch64 16.1.0 h2445e1f_101
+  - sysroot_linux-aarch64
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 75102801
+  timestamp: 1785374604361
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-py311h3512406_2.conda
+  sha256: 54d921defd947adb58a90e10203d3bfe6c1f209f5f1a1ad2c6a9f7617f2fb59e
+  md5: b35bbb1b957440ed742f35fb96eb7f1c
+  depends:
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - icu >=78.3,<79.0a0
+  size: 14688525
+  timestamp: 1786545779464
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.3-h5bc82ec_1.conda
+  sha256: 3999b1472f1e549a0b766428e2823abf20626aac5314b474c9b76bf6eb679def
+  md5: 6d9be306ecb8dfc9ff46f02cb367d5c2
+  depends:
+  - libgcc >=15
+  license: LGPL-2.1-or-later
+  purls: []
+  run_exports:
+    weak:
+    - keyutils >=1.6.3,<2.0a0
+  size: 129546
+  timestamp: 1786739205968
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.22.2-h095d8e5_2.conda
+  sha256: 601d79af94d9562ba70e2d4947034ba159aae293a3c860855335a7c76c14400e
+  md5: a4d0da122ba952abf76981e76d0d283c
+  depends:
+  - keyutils >=1.6.3,<2.0a0
+  - libedit >=3.1.20250104,<3.2.0a0
+  - libedit >=3.1.20250104,<4.0a0
+  - libgcc >=15
+  - libstdcxx >=15
+  - openssl >=3.5.7,<4.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - krb5 >=1.22.2,<1.23.0a0
+  size: 1538590
+  timestamp: 1786762058856
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.46.1-default_h1979696_102.conda
+  sha256: 2c4901f4227b0850328ed0c69f958b30ad2cd18982f7a31c7c1f911827004d08
+  md5: 489444d0acb2a579d2a002d85a08c059
+  depends:
+  - zstd >=1.5.7,<1.6.0a0
+  constrains:
+  - binutils_impl_linux-aarch64 2.46.1
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 905305
+  timestamp: 1784214534868
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.21.0-h23397ac_4.conda
+  sha256: 5a99beaf91963d212f9b488b5361a2d7aeb69ae3d44b40b65a3e87f128c5417e
+  md5: 5afef6f29ea234741802980cdcee6f5e
+  depends:
+  - krb5 >=1.22.2,<1.23.0a0
+  - libgcc >=14
+  - libnghttp2 >=1.68.1,<2.0a0
+  - libpsl >=0.23.0,<0.24.0a0
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.7,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: curl
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libcurl >=8.21.0,<9.0a0
+  size: 505770
+  timestamp: 1785500029413
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20250104-pl5321hc48eb74_1.conda
+  sha256: 2d7218da06f1121619335bff25a2669df810dee90d2eb65b17f8b2e6b1c0d372
+  md5: 6e06eb2c9fda76721699bcdd759b9c60
+  depends:
+  - ncurses
+  - libgcc >=14
+  - ncurses >=6.6,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - libedit >=3.1.20250104,<3.2.0a0
+  size: 149007
+  timestamp: 1786616643904
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h80f16a2_3.conda
+  sha256: 4475f79a020e9ff2a5a0308c48cb2970a25d55c3dd724a97ab28bfac3be6cd49
+  md5: f679b30a53d410d0b5ae0cb8f5b7397e
+  depends:
+  - libgcc >=14
+  license: BSD-2-Clause OR GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  run_exports:
+    weak:
+    - libev >=4.33,<4.34.0a0
+  size: 45746
+  timestamp: 1785917328690
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.8.1-hfae3067_1.conda
+  sha256: 20a5726bc8705d91437c9e6ef83b30da64a1719b869656d20a1ee818333ea5ac
+  md5: fac3b65a605cd253037fdf3daf2de8d9
+  depends:
+  - libgcc >=14
+  constrains:
+  - expat 2.8.1.*
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports: {}
+  size: 77649
+  timestamp: 1781203572523
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.7.0-h376a255_0.conda
+  sha256: c95b5b5fc13c8d7af2a9908e6c64844f48787a7631f8abcde1813dc21b3b079e
+  md5: 81aedbde3ea118c602e8b289bf565ac5
+  depends:
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libffi >=3.7.0,<3.8.0a0
+  size: 63746
+  timestamp: 1783520889209
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-16.1.0-h205dda4_1.conda
+  sha256: 88a3d400c678df034c9d498f32503779977d5ea826063687c663e42c945abed5
+  md5: 91eb209af1098d652fc69b8a3fc7cbaa
+  depends:
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgomp 16.1.0 h8acb6b2_1
+  - libgcc-ng ==16.1.0=*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 628785
+  timestamp: 1785374520532
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-16.1.0-h8acb6b2_1.conda
+  sha256: 1c609a4a72597350317b92c4d9dfb85d21740219048e2b1d458925a6ccfa3d7a
+  md5: 4c9b02fc9fe27704777e260157003653
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports:
+    strong:
+    - _openmp_mutex >=4.5
+  size: 617180
+  timestamp: 1785374444877
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-5.8.3-he30d5cf_1.conda
+  sha256: f760669fd1cea27f689f411c0d5488e26ce50e382c9b63e4ad348f959850124a
+  md5: e0e6411a60d00186eec7c73f4118ab67
+  depends:
+  - libgcc >=14
+  constrains:
+  - xz 5.8.3.*
+  license: 0BSD
+  purls: []
+  run_exports:
+    weak:
+    - liblzma >=5.8.3,<6.0a0
+  size: 125578
+  timestamp: 1786348561649
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libmpdec-4.0.0-he30d5cf_2.conda
+  sha256: 5d6621a2229777824386164b40c67ff804fe98dd4165354cf73ee73e282a2adf
+  md5: eaaaec4776cd8a7b987c4b1782220141
+  depends:
+  - libgcc >=14
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  run_exports: {}
+  size: 113885
+  timestamp: 1786650485380
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.68.1-hd3077d7_0.conda
+  sha256: 13782715b9eeebc4ad16d36e84ca569d1495e3516aea3fe546a32caa0a597d82
+  md5: be5f0f007a4500a226ef001115535a3d
+  depends:
+  - c-ares >=1.34.6,<2.0a0
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.5,<4.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libnghttp2 >=1.68.1,<2.0a0
+  size: 726928
+  timestamp: 1773854039807
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpsl-0.23.1-hb8431ed_1.conda
+  sha256: 757f79c182ac3080cf416acd91c7643b8074b8b2e5c1eba0ffc5a16897feb84b
+  md5: 5ab41e5e70b78eb00ef62cdaa35cd86f
+  depends:
+  - libgcc >=15
+  - libstdcxx >=15
+  - icu >=78.3,<79.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libpsl >=0.23.1,<0.24.0a0
+  size: 73118
+  timestamp: 1786970733378
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-16.1.0-h2510bd8_1.conda
+  sha256: 3dfccbcd3bf34923df7482df41bcdbe599675f2de6f03a554dbc238476693854
+  md5: ae3d9771453f2ec660dd79e5728129b3
+  depends:
+  - libgcc >=16.1.0
+  - libstdcxx >=16.1.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports:
+    weak:
+    - libsanitizer 16.1.0
+  size: 8123895
+  timestamp: 1785374560390
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.53.4-h022381a_0.conda
+  sha256: da46b52f6815e9771f4e21e3332c423c88644e91ac96b0534e85158adc88a8b4
+  md5: 99898219505ff142be5734dc6fa0d900
+  depends:
+  - libgcc >=14
+  - libzlib >=1.3.2,<2.0a0
+  license: blessing
+  purls: []
+  run_exports:
+    weak:
+    - libsqlite >=3.53.4,<4.0a0
+  size: 963888
+  timestamp: 1785016056926
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.1-h7572e3e_1.conda
+  sha256: f6fef76c1c8899d7976030871b8cd8016b0a306d2b8519834cd6491d6a42fb82
+  md5: 833be3f226277d894df3c7a7131d9532
+  depends:
+  - libgcc >=14
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.7,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - libssh2 >=1.11.1,<2.0a0
+  size: 315682
+  timestamp: 1786713068743
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-16.1.0-hef695bb_1.conda
+  sha256: 81ef9a10a0e01ffc7e03d429ed048410153411b2d8bbf95c334bdf3dcf175ab0
+  md5: 0bfd287b881e05351a01c7ebf7bf8f1b
+  depends:
+  - libgcc 16.1.0 h205dda4_1
+  constrains:
+  - libstdcxx-ng ==16.1.0=*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 6255794
+  timestamp: 1785374543663
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.42.2-h1022ec0_0.conda
+  sha256: 7663489f97c104ae3814db10f384932c74b439f3c1fd4247e4fe3599830c090a
+  md5: 58fa42bc4bc71fc329889497ec15effb
+  depends:
+  - libgcc >=14
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - libuuid >=2.42.2,<3.0a0
+  size: 43248
+  timestamp: 1781625528371
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuv-1.52.1-h80f16a2_1.conda
+  sha256: 52f4bc6e340bde53bfe38e45f6cb1080a2d5f8891da9a647087f7cc6a6edfc22
+  md5: 8e2136432f02841b9d8b848045f66d7d
+  depends:
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libuv >=1.52.1,<2.0a0
+  size: 457209
+  timestamp: 1785914582944
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.2-hdc9db2a_3.conda
+  sha256: 76efa6cc9d7e6f5ee3bbca0939f64054af2bdfb3c3632531f8e633cf6c2ea41e
+  md5: bd534c2fbe56d8c2ea3b2d8f5e12bca8
+  constrains:
+  - zlib 1.3.2 *_3
+  license: Zlib
+  license_family: Other
+  purls: []
+  run_exports:
+    weak:
+    - libzlib >=1.3.2,<2.0a0
+  size: 70108
+  timestamp: 1785276540870
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/maturin-1.14.1-py310hf87f8eb_2.conda
+  noarch: python
+  sha256: 5f3579cd00532a445d2cfc43f16d43ea2691b6b3d4c3659c150c78cef62ac02e
+  md5: 5a89fc5c95eb4c4dd0eaf26d064fa854
+  depends:
+  - python
+  - tomli >=1.1.0
+  - libgcc >=15
+  - openssl >=3.5.7,<4.0a0
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/maturin?source=compressed-mapping
+  run_exports: {}
+  size: 9435596
+  timestamp: 1786670692245
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.6-h2b6f883_1.conda
+  sha256: d69a04914139627f0a6bfd19412d6c7f1e37edc896af84a6011e07e8bc1e69fa
+  md5: c3b4349171ca987ff33a1de61f7b3f96
+  depends:
+  - libgcc >=14
+  license: X11 AND BSD-3-Clause
+  purls: []
+  run_exports:
+    weak:
+    - ncurses >=6.6,<7.0a0
+  size: 955422
+  timestamp: 1786355019431
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/onnxruntime-cpp-1.28.0-h106f1d4_0_cpu.conda
+  sha256: 63a3c4d02906cfe75f27683c67614bd0768706dc1d93d7092167610ff9530d68
+  md5: 4771ae1786dc934e3fea83d0c6fe405a
+  depends:
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT AND BSL-1.0
+  purls: []
+  run_exports:
+    weak:
+    - onnxruntime-cpp >=1.28.0,<1.28.1.0a0
+  size: 19474145
+  timestamp: 1786188185327
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.6.3-h546c87b_1.conda
+  sha256: c89e748e8a008e8ca6f25e102362f33319db0c98cc29d98ddada92842f636327
+  md5: 1600dfde78c5adba306f8571af62a323
+  depends:
+  - ca-certificates
+  - libgcc >=14
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  run_exports:
+    weak:
+    - openssl >=3.6.3,<4.0a0
+  size: 3719270
+  timestamp: 1785913554920
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.14.6-h1a34557_102_cp314.conda
+  build_number: 102
+  sha256: 299683c89d30f7e86cb5c7251a8ecac1ba0504543bc6ae8627bccac01839bed4
+  md5: cf7e3cad841cc2a70936dc4236ff2af4
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-aarch64 >=2.36.1
+  - libexpat >=2.8.1,<3.0a0
+  - libffi >=3.7.0,<3.8.0a0
+  - libgcc >=14
+  - liblzma >=5.8.3,<6.0a0
+  - libmpdec >=4.0.0,<5.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - libuuid >=2.42.2,<3.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - ncurses >=6.6,<7.0a0
+  - openssl >=3.5.7,<4.0a0
+  - python_abi 3.14.* *_cp314
+  - readline >=8.3,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - zstd >=1.5.7,<1.6.0a0
+  license: Python-2.0
+  purls: []
+  run_exports:
+    weak:
+    - python_abi 3.14.* *_cp314
+    noarch:
+    - python
+  size: 34809847
+  timestamp: 1786444473184
+  python_site_packages_path: lib/python3.14/site-packages
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
+  sha256: fe695f9d215e9a2e3dd0ca7f56435ab4df24f5504b83865e3d295df36e88d216
+  md5: 3d49cad61f829f4f0e0611547a9cda12
+  depends:
+  - libgcc >=14
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  run_exports:
+    weak:
+    - readline >=8.3,<9.0a0
+  size: 357597
+  timestamp: 1765815673644
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rhash-1.4.6-he30d5cf_2.conda
+  sha256: b4e49255aa581788c28f0a4a19ba49756cea968998c599f40feadcfeb80d15fb
+  md5: aa87887d8ec28a87ae84d996876e728e
+  depends:
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - rhash >=1.4.6,<2.0a0
+  size: 211434
+  timestamp: 1786731457243
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rust-1.97.1-h6cf38e9_1.conda
+  sha256: 7a676842c8722154f760c4b2f671d04c51b27c1a9a6f2e486cdf82245376a203
+  md5: 67a982ab4453c2c35892185e2d782cef
+  depends:
+  - gcc_impl_linux-aarch64
+  - libgcc >=14
+  - libzlib >=1.3.2,<2.0a0
+  - rust-std-aarch64-unknown-linux-gnu 1.97.1 hbe8e118_1
+  - sysroot_linux-aarch64 >=2.17
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    strong_constrains:
+    - __glibc >=2.17
+  size: 133536091
+  timestamp: 1786461687289
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_h5cf4473_3.conda
+  build_number: 103
+  sha256: cd51fbda051a9f3679d10ef4a94cd1ff38c10533b82845dadce8ba87245ba4ce
+  md5: 89e78452e06563964e419059ee45584a
+  depends:
+  - libgcc >=14
+  - libzlib >=1.3.2,<2.0a0
+  constrains:
+  - xorg-libx11 >=1.8.13,<2.0a0
+  license: TCL
+  purls: []
+  run_exports:
+    weak:
+    - tk >=8.6.13,<8.7.0a0
+  size: 3683040
+  timestamp: 1784229053797
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-h9d15635_7.conda
+  sha256: 427fd14bcb3b8659796fecc682716617409350fb5a98e5b7b47558a10d1a2fc7
+  md5: d942e34ac3920ba83f8b2d0169570187
+  depends:
+  - libzlib >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - zstd >=1.5.7,<1.6.0a0
+  size: 615477
+  timestamp: 1786599613561
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-h4c7d964_0.conda
+  sha256: 95e8e74062a5fe5f870ac8c90302b6e89945165fdaed7810606e84ddee6aac12
+  md5: e27d2ac27b096dc51fedfcf775a53f9b
+  depends:
+  - __win
+  license: ISC
+  purls: []
+  run_exports: {}
+  size: 132136
+  timestamp: 1784754918886
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+  sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+  md5: 0f51e2391ade309db462a55611263e9c
+  depends:
+  - __unix
+  license: ISC
+  purls: []
+  run_exports: {}
+  size: 131780
+  timestamp: 1784754889428
+- conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
+  sha256: 41557eeadf641de6aeae49486cef30d02a6912d8da98585d687894afd65b356a
+  md5: 86d9cba083cd041bfbf242a01a7a1999
+  constrains:
+  - sysroot_linux-64 ==2.28
+  license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 1278712
+  timestamp: 1765578681495
+- conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_9.conda
+  sha256: 5d224bf4df9bac24e69de41897c53756108c5271a0e5d2d2f66fd4e2fbc1d84b
+  md5: bb3b7cad9005f2cbf9d169fb30263f3e
+  constrains:
+  - sysroot_linux-aarch64 ==2.28
+  license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 1248134
+  timestamp: 1765578613607
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-16.1.0-h59071f9_101.conda
+  sha256: b314251d957b16c71ec241119ac09b9530c5c4ce140026ec98d297f55d6c5e08
+  md5: 19b0151ecb1d122f706ebd2f82f9a017
+  depends:
+  - __unix
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 3096495
+  timestamp: 1785375361053
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-16.1.0-hd673532_101.conda
+  sha256: 885f0d8a47f7ea50d7b33d07a240f2301935602b9d2a39a35b5018b13e934100
+  md5: 00cdfad75c8331e103f830fb17184da1
+  depends:
+  - __unix
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 2357226
+  timestamp: 1785374433650
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-16.1.0-h41cdd0d_101.conda
+  sha256: c1521172f2fdf5510d79b621ea835064209fe3131518e0d8b2b43362a75e7b4c
+  md5: 8593636203272a748b63d56cbd674753
+  depends:
+  - __unix
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 22519609
+  timestamp: 1785375386152
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-16.1.0-h2445e1f_101.conda
+  sha256: 926d2c2dedfca7334804d5c8a0727a3746ef580be8763f51ccc2ece24c7be56c
+  md5: d2cd8c4b92b4e6dbcb2616d855107aca
+  depends:
+  - __unix
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 19792513
+  timestamp: 1785374457502
+- conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.2.1-pyh145f28c_0.conda
+  sha256: 0f7021cfb3ff454c91a5e28e1f5060906a52c6d1cde3f879a7d03ac33c28b1c3
+  md5: 573cb3ed111004230ed3de650653cd4d
+  depends:
+  - python >=3.13.0a0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pip?source=hash-mapping
+  run_exports: {}
+  size: 1198163
+  timestamp: 1785914482439
+- conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+  build_number: 8
+  sha256: ad6d2e9ac39751cc0529dd1566a26751a0bf2542adb0c232533d32e176e21db5
+  md5: 0539938c55b6b1a59b560e843ad864a4
+  constrains:
+  - python 3.14.* *_cp314
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports: {}
+  size: 6989
+  timestamp: 1752805904792
+- conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-apple-darwin-1.97.1-hf6ec828_1.conda
+  sha256: 0e238479bdc0d6363d18d5f91b83bce79ca19b95520b913bd6948e413def3486
+  md5: db1eb0d780ce322bf7538efe0851659c
+  depends:
+  - __unix
+  constrains:
+  - rust >=1.97.1,<1.97.2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports: {}
+  size: 34973410
+  timestamp: 1786461702289
+- conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-unknown-linux-gnu-1.97.1-hbe8e118_1.conda
+  sha256: 6d8da2903c5662fc01b7f092255d07345bd7dce37e81b0c379f1bec1fd22b117
+  md5: df7f60d13a249f414b21ade531c9bbac
+  depends:
+  - __unix
+  constrains:
+  - rust >=1.97.1,<1.97.2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports: {}
+  size: 37467774
+  timestamp: 1786461618183
+- conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-pc-windows-msvc-1.97.1-h17fc481_1.conda
+  sha256: 89adf6ff3b0ff6521fbe1f98815f91bf43fd9b9f5bf39b62c71b96463df76795
+  md5: b0d47e376d05a679c72a568ac282edb1
+  depends:
+  - __win
+  constrains:
+  - rust >=1.97.1,<1.97.2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports: {}
+  size: 26804888
+  timestamp: 1786464050922
+- conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-unknown-linux-gnu-1.97.1-h2c6d0dc_1.conda
+  sha256: 934afbf999db3e89941b00a735c1283daf5f69980a2da09fc7abdc482fabffdf
+  md5: 1fe5e433fe682b8a8afc91cf9bcd78c8
+  depends:
+  - __unix
+  constrains:
+  - rust >=1.97.1,<1.97.2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports: {}
+  size: 37011732
+  timestamp: 1786462491313
+- conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
+  sha256: c47299fe37aebb0fcf674b3be588e67e4afb86225be4b0d452c7eb75c086b851
+  md5: 13dc3adbc692664cd3beabd216434749
+  depends:
+  - __glibc >=2.28
+  - kernel-headers_linux-64 4.18.0 he073ed8_9
+  - tzdata
+  license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  run_exports:
+    strong:
+    - __glibc >=2.28,<3.0.a0
+  size: 24008591
+  timestamp: 1765578833462
+- conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.28-h585391f_9.conda
+  sha256: 1bd2db6b2e451247bab103e4a0128cf6c7595dd72cb26d70f7fadd9edd1d1bc3
+  md5: fdf07ab944a222ff28c754914fdb0740
+  depends:
+  - __glibc >=2.28
+  - kernel-headers_linux-aarch64 4.18.0 h05a177a_9
+  - tzdata
+  license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  run_exports:
+    strong:
+    - __glibc >=2.28,<3.0.a0
+  size: 23644746
+  timestamp: 1765578629426
+- conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+  sha256: 91cafdb64268e43e0e10d30bd1bef5af392e69f00edd34dfaf909f69ab2da6bd
+  md5: b5325cf06a000c5b14970462ff5e4d58
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/tomli?source=hash-mapping
+  run_exports: {}
+  size: 21561
+  timestamp: 1774492402955
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+  sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+  md5: fcb489df604d100968b737f2cb6076c6
+  license: LicenseRef-Public-Domain
+  purls: []
+  run_exports: {}
+  size: 118849
+  timestamp: 1784250406640
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h4e30115_10.conda
+  sha256: 8ec22f0ba25cbfc2e64d70cf29459eccd7ffdf6436f6a6ff15bbfef799f7d4f6
+  md5: b50612e7d190b8061ab4e7dc119cf4d5
+  depends:
+  - __osx >=11.0
+  license: bzip2-1.0.6
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - bzip2 >=1.0.8,<2.0a0
+  size: 124965
+  timestamp: 1785906749812
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.8-h1a92334_1.conda
+  sha256: 104b41473845649101ba8ebf8221c7431256465d34ce380b10e9a90558ed33ac
+  md5: 7d9390a4d4b43f91652823d870f68065
+  depends:
+  - __osx >=11.0
+  constrains:
+  - c-ares-static <0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - c-ares >=1.34.8,<2.0a0
+  size: 197274
+  timestamp: 1786116660078
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cmake-4.4.2-hf91ab31_1.conda
+  sha256: 15e639e788fac8a1d68ff362e25fda5a9501064051c63be95404ecd42eece398
+  md5: db71b4b301e835d159db981ae1c8398d
+  depends:
+  - __osx >=11.0
+  - libcxx >=21
+  - liblzma >=5.8.3,<6.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libcurl >=8.21.0,<9.0a0
+  - libuv >=1.52.1,<2.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - rhash >=1.4.6,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ncurses >=6.6,<7.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports: {}
+  size: 20205878
+  timestamp: 1786961328614
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-py310h579977c_2.conda
+  sha256: 6cdb5dee54c72e56ab189fb3ad33cb28533553d42590e7e831160248f4416a43
+  md5: a5efc0b42bb8b42e97d0a29ae3e3c187
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - icu >=78.3,<79.0a0
+  size: 14070242
+  timestamp: 1786545847761
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-h34f8a20_2.conda
+  sha256: aaea1d42b07769920db2af7471ece9399d2613448863da64ad8272998db5db34
+  md5: 15235dd10450d67bc25ccafd5b46d2bc
+  depends:
+  - __osx >=11.0
+  - libcxx >=21
+  - libedit >=3.1.20250104,<3.2.0a0
+  - libedit >=3.1.20250104,<4.0a0
+  - openssl >=3.5.7,<4.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - krb5 >=1.22.2,<1.23.0a0
+  size: 1165740
+  timestamp: 1786762145768
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.21.0-hf618e03_4.conda
+  sha256: d25be36712d7f854a5f93513b9fbf1b0ee3219975b7fef4a3ee071b021b10167
+  md5: 66cf9c5003ee81ecdb0dc9f9df17bbe5
+  depends:
+  - __osx >=11.0
+  - krb5 >=1.22.2,<1.23.0a0
+  - libnghttp2 >=1.68.1,<2.0a0
+  - libpsl >=0.23.0,<0.24.0a0
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.7,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: curl
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libcurl >=8.21.0,<9.0a0
+  size: 411491
+  timestamp: 1785500129743
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
+  sha256: a2e7abab5add9750fab064c024394de48e49f97631c605ad5db5c8ac3fc769ef
+  md5: 89f76a2a21a3ec3ec983b5eb237c4113
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  purls: []
+  run_exports: {}
+  size: 569349
+  timestamp: 1781670209146
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321h26f1114_1.conda
+  sha256: 257c926f19e32bdb981fc674c76966049b6fc73f706bae58e9fed8757ad1da70
+  md5: 843ef89082f368cb889305084d3b483c
+  depends:
+  - ncurses
+  - __osx >=11.0
+  - ncurses >=6.6,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - libedit >=3.1.20250104,<3.2.0a0
+  size: 107742
+  timestamp: 1786616721640
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h1a92334_3.conda
+  sha256: c0100064506ae8abb432c5a506d474f10af2cf48c33d62bc221fb28b6d6ff6ac
+  md5: 19e86c8a6a47e92bb2e70ca12e758c5c
+  depends:
+  - __osx >=11.0
+  license: BSD-2-Clause OR GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  run_exports:
+    weak:
+    - libev >=4.33,<4.34.0a0
+  size: 39991
+  timestamp: 1785917376956
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+  sha256: 5af74261101e3c777399c6294b2b5d290e508153268eb2e9ff99c4d69834612f
+  md5: a915151d5d3c5bf039f5ccc8402a436f
+  depends:
+  - __osx >=11.0
+  constrains:
+  - expat 2.8.1.*
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports: {}
+  size: 69362
+  timestamp: 1781203631990
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-hcf2aa1b_0.conda
+  sha256: 2c6ac9a6cd65af89b2bd448518bb1e13b44a2e48c0d469398e37bcfc0092e832
+  md5: 92e8690d170d46d768c32553458c0105
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libffi >=3.7.0,<3.8.0a0
+  size: 43734
+  timestamp: 1783521647536
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_1.conda
+  sha256: 23d0630046a3e8b164d8f80f2b74ed2605af2e7050ab9913018056402fae4311
+  md5: 8ab10323068b107661a4b9a4af84f3b5
+  depends:
+  - __osx >=11.0
+  constrains:
+  - xz 5.8.3.*
+  license: 0BSD
+  purls: []
+  run_exports:
+    weak:
+    - liblzma >=5.8.3,<6.0a0
+  size: 91720
+  timestamp: 1786348695846
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_2.conda
+  sha256: 04cc136c5a956a73aa14e0a160b5822b0b29714e67b299fa1b1fd16dbcba5366
+  md5: ff33a4dbd93abc8a798cc4e0e7c8136d
+  depends:
+  - __osx >=11.0
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  run_exports: {}
+  size: 73289
+  timestamp: 1786651074391
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.68.1-h8f3e76b_0.conda
+  sha256: 2bc7bc3978066f2c274ebcbf711850cc9ab92e023e433b9631958a098d11e10a
+  md5: 6ea18834adbc3b33df9bd9fb45eaf95b
+  depends:
+  - __osx >=11.0
+  - c-ares >=1.34.6,<2.0a0
+  - libcxx >=19
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.5,<4.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libnghttp2 >=1.68.1,<2.0a0
+  size: 576526
+  timestamp: 1773854624224
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpsl-0.23.1-hdb0c161_1.conda
+  sha256: c8c3153df39abedf3413483f672151ad70f1adb0c06c192bdf7ec432c3616b07
+  md5: 5d270f716a2b4bc13df9af8612071b17
+  depends:
+  - __osx >=11.0
+  - libcxx >=21
+  - icu >=78.3,<79.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libpsl >=0.23.1,<0.24.0a0
+  size: 72673
+  timestamp: 1786970928205
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.4-h1ae2325_0.conda
+  sha256: 745662565e103f290e9dc4263bbd88285082f8cf699854fe2d5f1e35a4a0d326
+  md5: 0e3477c0c3e718dcf2eb74ccc8f68570
+  depends:
+  - __osx >=11.0
+  - icu >=78.3,<79.0a0
+  - libzlib >=1.3.2,<2.0a0
+  license: blessing
+  purls: []
+  run_exports:
+    weak:
+    - libsqlite >=3.53.4,<4.0a0
+  size: 929203
+  timestamp: 1785016131414
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.1-hbf2880b_1.conda
+  sha256: a056e518c3d2d09fbb1778cea80c0c95338fb24adf1a817bbf90fb484850a304
+  md5: d957a8eda98c49b073e8dcfd677c127a
+  depends:
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.7,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - libssh2 >=1.11.1,<2.0a0
+  size: 280492
+  timestamp: 1786714226814
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.52.1-h1a92334_1.conda
+  sha256: 4f47de9de1990efd998edbbd6793f89c8f02ffde987ae8120b1c006acefd2a04
+  md5: de09bd0f175611e94f21b28f8c708e80
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libuv >=1.52.1,<2.0a0
+  size: 122729
+  timestamp: 1785914645797
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_3.conda
+  sha256: a18fa5d5bac452401459f966cf0d872224e8080c4ff93c77e168d43ab42ef9d7
+  md5: f39288f0ea63ae962e1a2e4f355a0d75
+  depends:
+  - __osx >=11.0
+  constrains:
+  - zlib 1.3.2 *_3
+  license: Zlib
+  license_family: Other
+  purls: []
+  run_exports:
+    weak:
+    - libzlib >=1.3.2,<2.0a0
+  size: 47822
+  timestamp: 1785277049190
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/maturin-1.14.1-py310h277814e_2.conda
+  noarch: python
+  sha256: 5605f4b3cb5ccf62536e982d4c0b41d8b780ebef14c3adfd8ce6ffc8412fbca2
+  md5: 822b33d777fd395bc789fad6da2d788d
+  depends:
+  - python
+  - tomli >=1.1.0
+  - __osx >=11.0
+  - openssl >=3.5.7,<4.0a0
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/maturin?source=compressed-mapping
+  run_exports: {}
+  size: 8550441
+  timestamp: 1786670771773
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
+  sha256: 7024a48c8c0d0114ed4ab53c76bf9275d50e91ba7cea367a9aead638d3c29c68
+  md5: 3dfa0d0316dc246cd44937a557de4501
+  depends:
+  - __osx >=11.0
+  license: X11 AND BSD-3-Clause
+  purls: []
+  run_exports:
+    weak:
+    - ncurses >=6.6,<7.0a0
+  size: 804298
+  timestamp: 1786355189145
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/onnxruntime-cpp-1.28.0-h3a32141_0_cpu.conda
+  sha256: f44b7b2baef93bc521713532df8533b9207e20fc5204d1de45305467af45ef17
+  md5: ec5597de67d0238ba1eb68404756a032
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  license: MIT AND BSL-1.0 AND BSD-3-Clause
+  purls: []
+  run_exports:
+    weak:
+    - onnxruntime-cpp >=1.28.0,<1.28.1.0a0
+  size: 17749148
+  timestamp: 1786190471654
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_1.conda
+  sha256: 66be2283b5b37dcda1332b5e74c1782a8cb14fd2e62e0d38017c2d35bf73c119
+  md5: 65d1906712b85d1679263c518d011b5b
+  depends:
+  - __osx >=11.0
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  run_exports:
+    weak:
+    - openssl >=3.6.3,<4.0a0
+  size: 3109132
+  timestamp: 1785913735357
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.6-hf4d206d_102_cp314.conda
+  build_number: 102
+  sha256: 9767b5eee5cef50716708787bb3b4225d2a974bcd50653e856f9db5910a4b17e
+  md5: 8da4ea285021110e2617f7538c386afc
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libffi >=3.7.0,<3.8.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libmpdec >=4.0.0,<5.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - ncurses >=6.6,<7.0a0
+  - openssl >=3.5.7,<4.0a0
+  - python_abi 3.14.* *_cp314
+  - readline >=8.3,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - zstd >=1.5.7,<1.6.0a0
+  license: Python-2.0
+  purls: []
+  run_exports:
+    weak:
+    - python_abi 3.14.* *_cp314
+    noarch:
+    - python
+  size: 13960847
+  timestamp: 1786444540722
+  python_site_packages_path: lib/python3.14/site-packages
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
+  sha256: a77010528efb4b548ac2a4484eaf7e1c3907f2aec86123ed9c5212ae44502477
+  md5: f8381319127120ce51e081dce4865cf4
+  depends:
+  - __osx >=11.0
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  run_exports:
+    weak:
+    - readline >=8.3,<9.0a0
+  size: 313930
+  timestamp: 1765813902568
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rhash-1.4.6-h84a0fba_2.conda
+  sha256: b4da3ab88c407b4133d39512b3b615d6fb020c89d39f54491862e6731528ab95
+  md5: 5cec61f5b18ca8c5bbb1ad2dc5923a8e
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - rhash >=1.4.6,<2.0a0
+  size: 185483
+  timestamp: 1786732022220
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rust-1.97.1-h4ff7c5d_1.conda
+  sha256: 57eb48039043b7371bf9f2328b3d7309770f6dc4d9c993427770bba31efb1196
+  md5: ff377a9ba79d3f19b53aedab747b5587
+  depends:
+  - rust-std-aarch64-apple-darwin 1.97.1 hf6ec828_1
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports: {}
+  size: 182451854
+  timestamp: 1786461811762
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hd3d0363_3.conda
+  sha256: 47186bc7ab8d7e8bee86bbd1a917196f8c21cf63f081fc33cd6d1221af087580
+  md5: 8e3cf0e455e6b54519f0b1c72c61780a
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.2,<2.0a0
+  license: TCL
+  purls: []
+  run_exports:
+    weak:
+    - tk >=8.6.13,<8.7.0a0
+  size: 3338712
+  timestamp: 1784229090530
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hf451053_7.conda
+  sha256: da867f5092eb0cb746d353694f0098031fd9817a4ce7d5743121209ae0f406ca
+  md5: 4ec2684c73812cc2c3d78379384a39cc
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - zstd >=1.5.7,<1.6.0a0
+  size: 433687
+  timestamp: 1786599629846
+- conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_10.conda
+  sha256: 04767466ee9227c9c57ab2c6503e0149177d34111c7418d2f420297acb1eb229
+  md5: c3301c058362f340100d91cd8be0393f
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: bzip2-1.0.6
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - bzip2 >=1.0.8,<2.0a0
+  size: 55919
+  timestamp: 1785906343696
+- conda: https://conda.anaconda.org/conda-forge/win-64/cmake-4.4.2-hde52c71_1.conda
+  sha256: f575430909753e09d9c41838af77e6a8bfc4403eb9c079cd393b72ae5cf0d088
+  md5: fe53fecf3c9be5420fc3afb03c9c73eb
+  depends:
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - libzlib >=1.3.2,<2.0a0
+  - libuv >=1.52.1,<2.0a0
+  - libcurl >=8.21.0,<9.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - liblzma >=5.8.3,<6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports: {}
+  size: 17931097
+  timestamp: 1786961023901
+- conda: https://conda.anaconda.org/conda-forge/win-64/icu-78.3-h5112557_2.conda
+  sha256: 75c549b55b673e15de8785a8e5dd85bca7eb612eee0ff4dc8d7bdaa15eacbdbb
+  md5: e596942e8ee6ee17fdcf1e6a77757a66
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - icu >=78.3,<79.0a0
+  size: 16835644
+  timestamp: 1784916416303
+- conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.22.2-h719d79b_2.conda
+  sha256: 63ff03324e903eb01a715ccf357df56d66224e61952fd6615d86490ebefb3285
+  md5: 93f5a01dec294a2228f757fe2f3432d4
+  depends:
+  - openssl >=3.5.7,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - krb5 >=1.22.2,<1.23.0a0
+  size: 753425
+  timestamp: 1786762169034
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.21.0-hdb0ef4a_4.conda
+  sha256: af17c990ec52b6aba29e052c438d7ac61bfd541d6d183a8f09aa4f2c532c9bab
+  md5: 5e9c5b83929cf7ab2c04121af771e7b5
+  depends:
+  - krb5 >=1.22.2,<1.23.0a0
+  - libpsl >=0.23.0,<0.24.0a0
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: curl
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libcurl >=8.21.0,<9.0a0
+  size: 404586
+  timestamp: 1785500241182
+- conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
+  sha256: 1a54d874addda73b6f7164d5f3905821277a1831bcc05edd74b3085391688571
+  md5: ccc490c81ffe14181861beac0e8f3169
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - expat 2.8.1.*
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports: {}
+  size: 71631
+  timestamp: 1781203724164
+- conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.7.0-h3d046cb_0.conda
+  sha256: 2ea8d2fe7b84ca37653777e15ac1e7abd35f0c90d3efbe7f6c4de9b489606369
+  md5: 92bdfc0e5012660892b0e0eaf3069a5c
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libffi >=3.7.0,<3.8.0a0
+  size: 50247
+  timestamp: 1783521107166
+- conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.3-hfd05255_1.conda
+  sha256: d36c4a1e1f80fd08e18a407e03622ff2f34dfdd022da6488ad19603dea19e6d5
+  md5: 880a0c8549479b198af21ba5dc49b109
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - xz 5.8.3.*
+  license: 0BSD
+  purls: []
+  run_exports:
+    weak:
+    - liblzma >=5.8.3,<6.0a0
+  size: 105809
+  timestamp: 1786348717883
+- conda: https://conda.anaconda.org/conda-forge/win-64/libmpdec-4.0.0-hfd05255_2.conda
+  sha256: f07e451de3db1836b87f7aedf95c8e65cdb06c0e6105329ba24bb5f7b5c75e2a
+  md5: 5ae92fd6614edd024576e14069d7ad4c
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  run_exports: {}
+  size: 89109
+  timestamp: 1786650384519
+- conda: https://conda.anaconda.org/conda-forge/win-64/libpsl-0.23.1-h9b16d47_1.conda
+  sha256: e53fe3b09f82b59b644264133d6d148ac31bb5451b7583cff55690bf038f2f62
+  md5: 39cdf8c4f59e4d253cfa8091c8b3d7de
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - icu >=78.3,<79.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libpsl >=0.23.1,<0.24.0a0
+  size: 73511
+  timestamp: 1786970749988
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.53.4-hf5d6505_0.conda
+  sha256: 62e1c45ec71ab2e5deeeb0e47e7df6a609991e91d46348f16df50c68fee145c8
+  md5: ca0d59f40a02a15e9b5d0ff8db0f85e3
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: blessing
+  purls: []
+  run_exports:
+    weak:
+    - libsqlite >=3.53.4,<4.0a0
+  size: 1313790
+  timestamp: 1785016158097
+- conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.1-h734d217_1.conda
+  sha256: 1097b08429b4f53f5751a32c6d99a083d227ca7f7812c0b239eea124cec073a0
+  md5: a21dd9ca39e74910bb96989feb916420
+  depends:
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.7,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - libssh2 >=1.11.1,<2.0a0
+  size: 295149
+  timestamp: 1786713186180
+- conda: https://conda.anaconda.org/conda-forge/win-64/libuv-1.52.1-h6a83c73_1.conda
+  sha256: 0d62467380061cd0fa4b27e579c805a95c7ef55a41ecb067de0c4d2d42490c66
+  md5: 4ccef39545e98553cc900ea557dff085
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libuv >=1.52.1,<2.0a0
+  size: 331195
+  timestamp: 1785914602690
+- conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.2-hfd05255_3.conda
+  sha256: 0629c2cc0404d3bb29d6baa7b4ba62da80797015e86de050db81ea5a07050527
+  md5: 5d2ff29d465097458cc3ff6569151991
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - zlib 1.3.2 *_3
+  license: Zlib
+  license_family: Other
+  purls: []
+  run_exports:
+    weak:
+    - libzlib >=1.3.2,<2.0a0
+  size: 58529
+  timestamp: 1785276664143
+- conda: https://conda.anaconda.org/conda-forge/win-64/maturin-1.14.1-py310h3ce4601_2.conda
+  noarch: python
+  sha256: aea4cbf48ca6734af93842bfd71353ec5f98c966c9838527d76ed4c06f53c456
+  md5: b8746f3c901d100f37279673f2abf0f9
+  depends:
+  - python
+  - tomli >=1.1.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/maturin?source=compressed-mapping
+  run_exports: {}
+  size: 8600656
+  timestamp: 1786670725788
+- conda: https://conda.anaconda.org/conda-forge/win-64/onnxruntime-cpp-1.28.0-h50ebc8d_0_cpu.conda
+  sha256: fc6c41e397f6fd74083d6b4d08903cb0f38a6b78daf11468fbdb50cf62aaa1ca
+  md5: cca005382be3d8f147de0aca08141461
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT AND BSL-1.0
+  purls: []
+  run_exports:
+    weak:
+    - onnxruntime-cpp >=1.28.0,<1.28.1.0a0
+  size: 4959745
+  timestamp: 1786190982908
+- conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.6.3-hf411b9b_1.conda
+  sha256: 2ebff5a1b5793e82495bf33c91fba040e11ff23333c2385ac66d0c3aee2cc14c
+  md5: a978392692a910ba1c8920ccb1e784b3
+  depends:
+  - ca-certificates
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  run_exports:
+    weak:
+    - openssl >=3.6.3,<4.0a0
+  size: 9427535
+  timestamp: 1785915614585
+- conda: https://conda.anaconda.org/conda-forge/win-64/python-3.14.6-h53f6dd8_102_cp314.conda
+  build_number: 102
+  sha256: 9faac11f2b7813585f428310df3768e2a465205d76c3829f8ccbd05e6b98764f
+  md5: 048ad2c1b1faf11cda7bb8c7ec998b0c
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libffi >=3.7.0,<3.8.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libmpdec >=4.0.0,<5.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.7,<4.0a0
+  - python_abi 3.14.* *_cp314
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - zstd >=1.5.7,<1.6.0a0
+  license: Python-2.0
+  purls: []
+  run_exports:
+    weak:
+    - python_abi 3.14.* *_cp314
+    noarch:
+    - python
+  size: 17903528
+  timestamp: 1786444689733
+  python_site_packages_path: Lib/site-packages
+- conda: https://conda.anaconda.org/conda-forge/win-64/rust-1.97.1-hf8d6059_1.conda
+  sha256: 91a61fddc71308f964cc17bc390ca8a1a530186106ab9bfb42faa3310d81cb66
+  md5: 0c7714de0414856c5b678a2e5ea14145
+  depends:
+  - rust-std-x86_64-pc-windows-msvc 1.97.1 h17fc481_1
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports: {}
+  size: 192771786
+  timestamp: 1786464169925
+- conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h967ab96_3.conda
+  sha256: 13fa29257d43f8e630a1e591ed77fae9bbbb236b011432f01e2034cf36e6bf03
+  md5: aaf79e2af50a151fb5b5a3e3f38b7a69
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  license: TCL
+  purls: []
+  run_exports:
+    weak:
+    - tk >=8.6.13,<8.7.0a0
+  size: 3782314
+  timestamp: 1784229072899
+- conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
+  sha256: 3005729dce6f3d3f5ec91dfc49fc75a0095f9cd23bab49efb899657297ac91a5
+  md5: 71b24316859acd00bdb8b38f5e2ce328
+  constrains:
+  - vc14_runtime >=14.29.30037
+  - vs2015_runtime >=14.29.30037
+  license: LicenseRef-MicrosoftWindowsSDK10
+  purls: []
+  run_exports: {}
+  size: 694692
+  timestamp: 1756385147981
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-ha367084_41.conda
+  sha256: 35444c55a92e2f7f7ba26bc70f81e56e52344f7d064c0fd4b40a46a58517b79c
+  md5: aa805b5522c2a98fa286e551a1f48546
+  depends:
+  - vc14_runtime >=14.51.36247
+  track_features:
+  - vc14
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports: {}
+  size: 21383
+  timestamp: 1785359368566
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36247-habf1de7_41.conda
+  sha256: 4e4cb599cdc41bf2109d1464c127b5bcbddf548ce3e322e612afb691338b48f8
+  md5: ac5333bb3d429361f23adf704cc49a78
+  depends:
+  - ucrt >=10.0.20348.0
+  - vcomp14 14.51.36247 habf1de7_41
+  constrains:
+  - vs2015_runtime 14.51.36247.* *_41
+  license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
+  license_family: Proprietary
+  purls: []
+  run_exports: {}
+  size: 767955
+  timestamp: 1785359364369
+- conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36247-habf1de7_41.conda
+  sha256: 731e043390c9457299484d39e427221fc868a9249540a498a5a4f6456c7744d1
+  md5: 350bb67a5c8e5f1c53347ac544ab6600
+  depends:
+  - ucrt >=10.0.20348.0
+  constrains:
+  - vs2015_runtime 14.51.36247.* *_41
+  license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
+  license_family: Proprietary
+  purls: []
+  run_exports:
+    strong:
+    - vcomp14 >=14.51.36247
+  size: 155910
+  timestamp: 1785359349999
+- conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_7.conda
+  sha256: ca7daae4f218a11fab82cc2857f0ea518ec3f46acec60490485347a4c22c6b3e
+  md5: e4ac308c39d6d0e131154976da67cf3b
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - libzlib >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - zstd >=1.5.7,<1.6.0a0
+  size: 387535
+  timestamp: 1786599623274
+- pypi: https://files.pythonhosted.org/packages/15/5c/7bcbd5b11f94199073320410cddcbb80cee62415bfeb540874b265c2d922/numpy-2.5.2-cp314-cp314-win_amd64.whl
+  name: numpy
+  version: 2.5.2
+  sha256: 7587f53dfbd5edc0f7b87c6217b4c6d2d1f2ef9c3da70bc1315e7db5f8d7ec9d
+  requires_python: '>=3.12'
+- pypi: https://files.pythonhosted.org/packages/17/e1/2c1d4b1987795a92b5bbf7c24fe249ab96aa2573ab0d7604802c189d7b86/numpy-2.5.2-cp314-cp314-macosx_11_0_arm64.whl
+  name: numpy
+  version: 2.5.2
+  sha256: 24b9dc2e3d84aa58523798805194e23e736f3f6ce2d1a5b92583ae734e6dbda8
+  requires_python: '>=3.12'
+- pypi: https://files.pythonhosted.org/packages/c4/3b/ecd49dd90033cceb2704d88ca905d4d7d89b0e8c739608754ffd325fa820/numpy-2.5.2-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
+  name: numpy
+  version: 2.5.2
+  sha256: 50e500dc868e9313530ce12ba470fe50ff3afe3d62993ed6eff652dacd555b65
+  requires_python: '>=3.12'
+- pypi: https://files.pythonhosted.org/packages/c7/99/461bd36dbdfac6c1c53efa370bd55a83227542d0d118f1677dbf1a3dacd5/numpy-2.5.2-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+  name: numpy
+  version: 2.5.2
+  sha256: 318b9a4c845dbea06708a29c84ee429cc3065048db34cdb799047643492050ee
+  requires_python: '>=3.12'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,3 +95,18 @@ exclude = [
 
 [tool.uv.extra-build-dependencies]
 eventcv = ["maturin"]
+
+[tool.pixi.workspace]
+channels = ["conda-forge"]
+platforms = ["linux-64", "linux-aarch64", "osx-arm64", "win-64"]
+
+[tool.pixi.tasks]
+build = "maturin build"
+develop = "maturin develop"
+
+[tool.pixi.dependencies]
+cmake = ">=3.18"
+maturin = ">=1.8,<2"
+onnxruntime-cpp = ">=1.28,<1.29"
+pip = ">=26.2.1,<27"
+rust = ">=1.97.1,<1.98"

--- a/python/eventcv/__main__.py
+++ b/python/eventcv/__main__.py
@@ -172,19 +172,24 @@ def _cmd_render(args: argparse.Namespace) -> int:
 
 def _cmd_play(args: argparse.Namespace) -> int:
     """Play a recording in an interactive window."""
-    from . import open as open_reader
+    from . import open as open_reader, play
 
-    reader = open_reader(args.input, **_source_options(args))
-    reader.play(
+    kwargs = dict(
         fps=args.fps,
         dt_ms=args.dt_ms,
         decay_ms=args.decay_ms,
         repr=args.repr,
         colormap=args.colormap,
+        clim=args.clim,
         speed=args.speed,
+        refresh_hz=args.refresh_hz,
         loop_=args.loop,
         max_frames=args.max_frames,
     )
+    if args.input is None:
+        play(**kwargs)
+    else:
+        open_reader(args.input, **_source_options(args)).play(**kwargs)
     return 0
 
 
@@ -322,14 +327,23 @@ def build_parser() -> argparse.ArgumentParser:
     render.set_defaults(func=_cmd_render)
 
     play = subparsers.add_parser(
-        "play", help="play a recording in an interactive window"
+        "play", help="open the interactive recording player"
     )
-    play.add_argument("input", help="source recording")
+    play.add_argument("input", nargs="?", default=None, help="source recording (optional)")
     _add_source_options(play)
     play.add_argument(
-        "--dt-ms", type=float, default=30.0, metavar="MS", help="time per frame (default: 30)"
+        "--dt-ms",
+        type=float,
+        default=30.0,
+        metavar="MS",
+        help="sliding accumulation width (default: 30)",
     )
-    play.add_argument("--fps", type=float, default=30.0, help="display frame rate (default: 30)")
+    play.add_argument(
+        "--fps",
+        type=float,
+        default=None,
+        help="deprecated fixed display rate; use --speed (default: recording time)",
+    )
     play.add_argument(
         "--repr",
         default="raw",
@@ -341,7 +355,17 @@ def build_parser() -> argparse.ArgumentParser:
     )
     play.add_argument("--colormap", default="viridis", help="colormap for scalar representations")
     play.add_argument(
+        "--clim", type=float, default=None, metavar="MAX", help="fixed colormap upper limit"
+    )
+    play.add_argument(
         "--speed", type=float, default=1.0, help="playback rate multiplier (default: 1)"
+    )
+    play.add_argument(
+        "--refresh-hz",
+        type=float,
+        default=60.0,
+        metavar="HZ",
+        help="maximum sliding-window refresh rate (default: 60)",
     )
     play.add_argument("--loop", action="store_true", help="restart at the end instead of closing")
     play.add_argument(

--- a/python/eventcv/load.py
+++ b/python/eventcv/load.py
@@ -431,7 +431,7 @@ def stream(
     ``.csv``, ``.bag``, ``.aedat``, ``.aedat4``, ``.dat``, ``.raw``) to archive the session while you
     work: every window the loop reads has its **raw** events appended to that file first, so a
     ``repr=`` loop processes representations live and still keeps the full-resolution recording for
-    later. Writing happens in Rust as each window is polled — no per-window Python round trip — and
+    later. Writing happens in Rust as each window is decoded — no per-window Python round trip — and
     is flushed about once a second, so a crash keeps everything up to a second ago.
 
     Formats differ in *when* the file becomes readable, which matters for a capture that might be
@@ -439,9 +439,9 @@ def stream(
     recording after every window, while npz and rosbag have a header or an index to write at the end
     and are only complete once the camera is closed. ``compression`` is an optional gzip level
     (``0..=9``) for HDF5; omit it for the fastest writes. The file is closed by :meth:`EventCamera.close` or
-    the ``with`` block, and :attr:`EventCamera.n_recorded` counts what has been written. Only windows
-    that are actually read are recorded (``show()`` doesn't poll them); to record without a loop, use
-    :meth:`EventCamera.record` instead.
+    the ``with`` block, and :attr:`EventCamera.n_recorded` counts what has been written. Iteration and
+    the event GUI both keep this background recorder running; :meth:`EventCamera.record` is the
+    blocking alternative when no interactive view or loop is needed.
 
     **Capping the source.** Every event costs time to decode, window, and render, so the cheapest
     event is one the camera never sends. ``max_event_rate`` (events per second) enables the sensor's
@@ -529,9 +529,9 @@ def stream(
     the driver's ring is drained continuously no matter what your loop is doing — the loop only
     collects windows that are already decoded. On a Prophesee EVK4 at ``dt_ms=50`` this leaves
     ~80% of each window's wall-clock budget free for your own work: 40 ms of per-frame processing
-    still holds 19.9 of an ideal 20 fps with the ring empty. (:meth:`EventCamera.show`,
-    :meth:`EventCamera.record`, and :meth:`EventCamera.close` pause the thread and take the camera
-    back, then it restarts on the next read.)
+    still holds 19.9 of an ideal 20 fps with the ring empty. The event GUI uses this same pump;
+    :meth:`EventCamera.record`, :meth:`EventCamera.draw_mask`, APS viewing, and
+    :meth:`EventCamera.close` take the camera back directly.
 
     Windows are delivered in order, so a loop whose per-window work is slower than the camera still
     falls behind — the thread buffers a few windows, then applies backpressure, and under *sustained*
@@ -545,10 +545,10 @@ def stream(
     The returned camera is a context manager and an iterator::
 
         # Live raw event view (the default) — polarity dots with exponential decay:
-        eventcv.stream().show()
+        eventcv.stream().show()                      # 30 ms window, up to 60 refreshes/s
 
         # Live representation view:
-        eventcv.stream(dt_ms=30).show("count")
+        eventcv.stream(dt_ms=30).show("count", refresh_hz=60)
 
         # Iterate windows and run any eventcv op on the live feed:
         with eventcv.stream(dt_ms=30) as cam:
@@ -966,22 +966,26 @@ def save_video(
     return source.save_video(path, **kwargs)
 
 
-def play(source, **kwargs) -> None:
-    """Open an interactive window playing ``source`` — an :class:`EventReader`, an
-    :class:`EventStream`, or a path.
+def play(source=None, **kwargs) -> None:
+    """Open the interactive player, optionally with an :class:`EventReader`,
+    :class:`EventStream`, or path already loaded.
 
     The offline twin of :meth:`EventCamera.show`: with no ``repr`` it shows the raw event stream,
     polarity dots fading by age, so watching a recording takes no more setup than watching a
     camera::
 
-        ecv.play("rec.h5", dt_ms=5)             # raw, six times slower than real time at 30 fps
+        ecv.play()                              # choose a recording in the GUI
+        ecv.play("rec.h5", dt_ms=5)
         ecv.play("rec.h5", repr="count", dt_ms=20)
         ecv.play(events, speed=0.25)
 
-    Blocks on the main thread until the window is closed (``Esc`` or the close button). Keyword
-    arguments are those of :meth:`EventReader.play` / :meth:`EventStream.play` — ``fps``,
-    ``dt_ms``, ``decay_ms``, ``speed``, ``loop_``, and for a reader also ``repr``/``colormap``.
+    At ``speed=1`` recording time matches wall time. ``dt_ms`` is the accumulation width while
+    ``refresh_hz`` (default 60) controls how often that window advances, so overlapping windows are
+    cheap. ``fps`` remains accepted for compatibility but is deprecated. The call blocks on the
+    main thread until the window is closed.
     """
+    if source is None:
+        return _rust.play_gui(**kwargs)
     if isinstance(source, str):
         source = open(source)
     return source.play(**kwargs)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,7 @@ import io
 import shutil
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 
 import numpy as np
@@ -138,6 +139,52 @@ class RenderTests(unittest.TestCase):
         self.assertEqual(code, 1)
         self.assertIn(".gif", err)
         self.assertNotIn("Traceback", err)
+
+
+class PlayTests(unittest.TestCase):
+    def test_play_without_a_file_opens_the_empty_player(self):
+        with mock.patch("eventcv.play") as play:
+            code, _, _ = _run("play", "--speed", "0.5", "--refresh-hz", "120")
+        self.assertEqual(code, 0)
+        play.assert_called_once()
+        self.assertEqual(play.call_args.kwargs["speed"], 0.5)
+        self.assertEqual(play.call_args.kwargs["refresh_hz"], 120.0)
+        self.assertIsNone(play.call_args.kwargs["fps"])
+
+    def test_play_file_preserves_source_and_view_options(self):
+        reader = mock.Mock()
+        with mock.patch("eventcv.open", return_value=reader) as open_reader:
+            code, _, _ = _run(
+                "play",
+                str(EXAMPLE_NPZ),
+                "--time-unit",
+                "us",
+                "--repr",
+                "count",
+                "--clim",
+                "4",
+                "--fps",
+                "20",
+            )
+        self.assertEqual(code, 0)
+        open_reader.assert_called_once_with(str(EXAMPLE_NPZ), time_unit="us")
+        reader.play.assert_called_once()
+        self.assertEqual(reader.play.call_args.kwargs["repr"], "count")
+        self.assertEqual(reader.play.call_args.kwargs["clim"], 4.0)
+        self.assertEqual(reader.play.call_args.kwargs["fps"], 20.0)
+
+    def test_public_play_accepts_no_source(self):
+        with mock.patch.object(eventcv._rust, "play_gui") as player:
+            eventcv.play(speed=2.0)
+        player.assert_called_once_with(speed=2.0)
+
+    def test_refresh_rate_is_bounded_before_launch(self):
+        with self.assertRaisesRegex(ValueError, "between 1 and 240"):
+            eventcv.play(refresh_hz=0)
+
+    def test_legacy_fps_warns_before_launching(self):
+        with self.assertWarns(DeprecationWarning), self.assertRaises(ValueError):
+            eventcv.play(fps=30.0, max_frames=0)
 
 
 class SimulateCommandTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

- add a locked Pixi development environment for the supported platforms
- add an egui/WGPU player with sliding-window playback, statistics, processors, and live-stream support
- expose the player through the Python API and CLI, with updated documentation and compatibility coverage

## Checks

Previously completed before publishing:

- Rust core and eventcv-py test suites
- Python, CLI, and camera test suites
- `pixi run develop`
- `git diff --check`

No additional tests were run while creating this fork, commit, and pull request, as requested.