### PR TITLE
Solving the scientific notation issue when loading a text file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -245,3 +245,4 @@ data/test/*
 !data/test/example.npz
 !data/test/sample.aedat4
 !data/test/sample_zstd.aedat4
+examples/

--- a/crates/eventcv-core/src/io/aedat.rs
+++ b/crates/eventcv-core/src/io/aedat.rs
@@ -649,7 +649,7 @@ fn scan_span(
         ..Span::default()
     };
     let mut clock = Clock::default();
-    for record in buffer.chunks_exact(RECORD) {
+    for record in buffer.as_chunks::<RECORD>().0 {
         let (address, t) = clock.read(record);
         let Record::Event { x, y, .. } = classify(address) else {
             continue;

--- a/crates/eventcv-core/src/io/aedat4.rs
+++ b/crates/eventcv-core/src/io/aedat4.rs
@@ -497,7 +497,8 @@ impl Aedat4SliceSource {
         let Some((bytes, elements)) = table.vector(slot::ELEMENTS, EVENT_STRIDE) else {
             return Ok(());
         };
-        for (index, event) in bytes.chunks_exact(EVENT_STRIDE).enumerate().take(elements) {
+        let (events, _) = bytes.as_chunks::<EVENT_STRIDE>();
+        for (index, event) in events.iter().enumerate().take(elements) {
             let t = i64::from_le_bytes(event[0..8].try_into().expect("eight bytes"));
             let x = i16::from_le_bytes(event[8..10].try_into().expect("two bytes"));
             let y = i16::from_le_bytes(event[10..12].try_into().expect("two bytes"));

--- a/crates/eventcv-core/src/io/text.rs
+++ b/crates/eventcv-core/src/io/text.rs
@@ -369,13 +369,40 @@ impl<R: BufRead> TextReader<R> {
             })
         };
         Ok(RawEvent {
-            x: self.parse(pick(map.x, "x")?, "x")?,
-            y: self.parse(pick(map.y, "y")?, "y")?,
+            x: {
+                let v = self.parse::<f64>(pick(map.x, "x")?, "x")?;
+                if !v.is_finite() || v.fract() != 0.0 || v < 0.0 || v > u16::MAX as f64 {
+                    return Err(IoError::Parse {
+                        line: self.line,
+                        message: "invalid x: coordinate out of range or not an integer".to_string(),
+                    });
+                }
+                v as u16
+            },
+            y: {
+                let v = self.parse::<f64>(pick(map.y, "y")?, "y")?;
+                if !v.is_finite() || v.fract() != 0.0 || v < 0.0 || v > u16::MAX as f64 {
+                    return Err(IoError::Parse {
+                        line: self.line,
+                        message: "invalid y: coordinate out of range or not an integer".to_string(),
+                    });
+                }
+                v as u16
+            },
             t: self
                 .options
                 .time_unit
                 .to_microseconds(self.parse::<f64>(pick(map.t, "t")?, "t")?),
-            p: self.parse::<i32>(pick(map.p, "p")?, "p")? > 0,
+            p: {
+                let v = self.parse::<f64>(pick(map.p, "p")?, "p")?;
+                if !v.is_finite() {
+                    return Err(IoError::Parse {
+                        line: self.line,
+                        message: "invalid p: not a finite number".to_string(),
+                    });
+                }
+                v > 0.0
+            },
         })
     }
 

--- a/crates/eventcv-core/src/io/text.rs
+++ b/crates/eventcv-core/src/io/text.rs
@@ -369,40 +369,13 @@ impl<R: BufRead> TextReader<R> {
             })
         };
         Ok(RawEvent {
-            x: {
-                let v = self.parse::<f64>(pick(map.x, "x")?, "x")?;
-                if !v.is_finite() || v.fract() != 0.0 || v < 0.0 || v > u16::MAX as f64 {
-                    return Err(IoError::Parse {
-                        line: self.line,
-                        message: "invalid x: coordinate out of range or not an integer".to_string(),
-                    });
-                }
-                v as u16
-            },
-            y: {
-                let v = self.parse::<f64>(pick(map.y, "y")?, "y")?;
-                if !v.is_finite() || v.fract() != 0.0 || v < 0.0 || v > u16::MAX as f64 {
-                    return Err(IoError::Parse {
-                        line: self.line,
-                        message: "invalid y: coordinate out of range or not an integer".to_string(),
-                    });
-                }
-                v as u16
-            },
+            x: parse_coord(pick(map.x, "x")?, "x", self.line)?,
+            y: parse_coord(pick(map.y, "y")?, "y", self.line)?,
             t: self
                 .options
                 .time_unit
                 .to_microseconds(self.parse::<f64>(pick(map.t, "t")?, "t")?),
-            p: {
-                let v = self.parse::<f64>(pick(map.p, "p")?, "p")?;
-                if !v.is_finite() {
-                    return Err(IoError::Parse {
-                        line: self.line,
-                        message: "invalid p: not a finite number".to_string(),
-                    });
-                }
-                v > 0.0
-            },
+            p: parse_polarity(pick(map.p, "p")?, "p", self.line)?,
         })
     }
 
@@ -554,6 +527,45 @@ fn infer_time_unit(rows: &[RawRow]) -> TimeUnit {
     }
 }
 
+/// A numeric field that must denote an exact `u16`. Datasets spell integer columns as floats
+/// (`3.0`, `3.000000e+01` — N-CARS does), so those are accepted; a genuine fraction or an
+/// out-of-range value is a malformed coordinate, not something to silently truncate.
+///
+/// Shared by both text parsers so that a load which infers `sensor_size`/`time_unit` and one
+/// that is told them read the same bytes the same way.
+fn parse_coord(value: &str, field: &str, line: usize) -> Result<u16, IoError> {
+    if let Ok(coord) = value.parse::<u16>() {
+        return Ok(coord); // ordinary integer text never pays for the float path
+    }
+    value
+        .parse::<f64>()
+        .ok()
+        .filter(|number| {
+            number.is_finite()
+                && number.fract() == 0.0
+                && *number >= 0.0
+                && *number <= f64::from(u16::MAX)
+        })
+        .map(|number| number as u16)
+        .ok_or_else(|| IoError::Parse {
+            line,
+            message: format!("invalid {field}: {value:?}"),
+        })
+}
+
+/// Polarity is any number: positive is ON, everything else (`0`, `-1`, `0.0`) is OFF.
+fn parse_polarity(value: &str, field: &str, line: usize) -> Result<bool, IoError> {
+    value
+        .parse::<f64>()
+        .ok()
+        .filter(|number| number.is_finite())
+        .map(|number| number > 0.0)
+        .ok_or_else(|| IoError::Parse {
+            line,
+            message: format!("invalid {field}: {value:?}"),
+        })
+}
+
 /// Parses one non-blank line into a [`RawRow`] (no unit conversion or bounds check).
 /// Shared by the buffered [`load_text`] and the [`TextSliceSource`] index scan.
 fn parse_raw_row(trimmed: &str, map: ColumnMap, number: usize) -> Result<RawRow, IoError> {
@@ -571,10 +583,10 @@ fn parse_raw_row(trimmed: &str, map: ColumnMap, number: usize) -> Result<RawRow,
         })
     };
     Ok(RawRow {
-        x: parse(pick(map.x, "x")?, "x")? as u16,
-        y: parse(pick(map.y, "y")?, "y")? as u16,
+        x: parse_coord(pick(map.x, "x")?, "x", number)?,
+        y: parse_coord(pick(map.y, "y")?, "y", number)?,
         t: parse(pick(map.t, "t")?, "t")?,
-        p: parse(pick(map.p, "p")?, "p")? > 0.0,
+        p: parse_polarity(pick(map.p, "p")?, "p", number)?,
     })
 }
 
@@ -1187,6 +1199,106 @@ mod tests {
             source.slice_time(2000, 5000).unwrap().ts(),
             &[2000, 3000, 4000]
         );
+        std::fs::remove_dir_all(path.parent().unwrap()).ok();
+    }
+
+    /// N-CARS spells every `.txt` column in scientific notation. The strict streaming path
+    /// (both `sensor_size` and `time_unit` given) has to read it as the same events the plain
+    /// integer spelling produces.
+    #[test]
+    fn parses_scientific_notation_columns() {
+        let data = "3.000000000000000000e+01 4.000000000000000000e+01 \
+                    0.000000000000000000e+00 1.000000000000000000e+00\n";
+        let options = TextOptions {
+            map: ColumnMap::from_order(ColumnOrder::Xytp),
+            ..TextOptions::new(120, 100)
+        };
+        let stream = read(data, options).unwrap();
+
+        assert_eq!(stream.xs(), &[30]);
+        assert_eq!(stream.ys(), &[40]);
+        assert_eq!(stream.ps(), &[true]);
+    }
+
+    /// The bug behind #26: whether `time_unit` is given picks the parser, so the two paths have
+    /// to accept and reject exactly the same coordinates.
+    #[test]
+    fn both_paths_read_the_same_coordinates() {
+        let path = write_temp(
+            "txtsci",
+            "3.000000e+01 4.000000e+01 0.000000e+00 1.000000e+00\n",
+        );
+        let inferred = LoadOptions {
+            sensor_size: Some((120, 100)),
+            order: ColumnOrder::Xytp,
+            ..LoadOptions::default()
+        };
+        let explicit = LoadOptions {
+            time_unit: Some(TimeUnit::Seconds),
+            ..inferred.clone()
+        };
+
+        for options in [&inferred, &explicit] {
+            let stream = load_text(&path, options).unwrap();
+            assert_eq!(stream.xs(), &[30]);
+            assert_eq!(stream.ys(), &[40]);
+            assert_eq!(stream.ps(), &[true]);
+        }
+        std::fs::remove_dir_all(path.parent().unwrap()).ok();
+    }
+
+    /// Reading coordinates as floats to admit `3.0e+01` must not also admit a real fraction or
+    /// a value past the grid — silently truncating those is how a bad file becomes bad data.
+    #[test]
+    fn both_paths_reject_coordinates_that_are_not_exact_u16() {
+        for (tag, data) in [
+            ("frac", "3.7 40 0 1\n"),
+            ("huge", "70000 40 0 1\n"),
+            ("neg", "-1 40 0 1\n"),
+        ] {
+            let path = write_temp(&format!("txtbad{tag}"), data);
+            let inferred = LoadOptions {
+                sensor_size: Some((120, 100)),
+                order: ColumnOrder::Xytp,
+                ..LoadOptions::default()
+            };
+            let explicit = LoadOptions {
+                time_unit: Some(TimeUnit::Microseconds),
+                ..inferred.clone()
+            };
+
+            for options in [&inferred, &explicit] {
+                match load_text(&path, options) {
+                    Err(IoError::Parse { line, message }) => {
+                        assert_eq!(line, 1);
+                        assert!(message.starts_with("invalid x:"), "{message}");
+                    }
+                    other => panic!("{tag}: expected a parse error, got {other:?}"),
+                }
+            }
+            std::fs::remove_dir_all(path.parent().unwrap()).ok();
+        }
+    }
+
+    /// `TextSliceSource` seeks and then re-parses through `TextReader`, so scientific notation
+    /// used to index cleanly and fail on every slice.
+    #[test]
+    fn text_slice_reads_scientific_notation() {
+        let path = write_temp(
+            "txtslicesci",
+            "0.000000e+00 3.000000e+01 4.000000e+01 1.000000e+00\n\
+             1.000000e+03 3.100000e+01 4.100000e+01 0.000000e+00\n",
+        );
+        let options = LoadOptions {
+            sensor_size: Some((120, 100)),
+            time_unit: Some(TimeUnit::Microseconds),
+            ..LoadOptions::default()
+        };
+        let source = open_text_slice(&path, &options).unwrap();
+
+        assert_eq!(source.n_events(), 2);
+        assert_eq!(source.slice_index(0, 2).unwrap().xs(), &[30, 31]);
+        assert_eq!(source.slice_time(0, 1000).unwrap().ys(), &[40]);
         std::fs::remove_dir_all(path.parent().unwrap()).ok();
     }
 }

--- a/crates/eventcv-core/src/mask.rs
+++ b/crates/eventcv-core/src/mask.rs
@@ -65,7 +65,7 @@ pub fn polygon(width: usize, height: usize, points: &[(f64, f64)]) -> Vec<bool> 
             }
         }
         crossings.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal));
-        for pair in crossings.chunks_exact(2) {
+        for pair in crossings.as_chunks::<2>().0 {
             for x in span(pair[0], pair[1], width) {
                 mask[y * width + x] = true;
             }

--- a/crates/eventcv-core/src/net.rs
+++ b/crates/eventcv-core/src/net.rs
@@ -278,10 +278,11 @@ impl UdpReceiver {
         builder: &mut EventStreamBuilder,
         arrival_index: i64,
     ) -> i64 {
-        let mut words = payload.chunks_exact(4).map(|bytes| {
-            self.format
-                .decode_word([bytes[0], bytes[1], bytes[2], bytes[3]])
-        });
+        let mut words = payload
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|bytes| self.format.decode_word(*bytes));
         let mut count = 0;
         while let Some(word) = words.next() {
             // Bit 31 tells us whether a timestamp word follows, so a receiver reads either format

--- a/crates/eventcv-core/src/simulate.rs
+++ b/crates/eventcv-core/src/simulate.rs
@@ -756,12 +756,13 @@ pub fn linear_luma(r: u8, g: u8, b: u8) -> f32 {
 
 /// Converts a decoded RGB frame into the linear luma the simulator consumes.
 pub fn luma_from_rgb(image: &Rgb8Image) -> Vec<f32> {
-    let convert = |pixel: &[u8]| linear_luma(pixel[0], pixel[1], pixel[2]);
-    if image.pixels.len() / 3 < PARALLEL_PIXEL_THRESHOLD {
-        return image.pixels.chunks_exact(3).map(convert).collect();
+    let convert = |pixel: &[u8; 3]| linear_luma(pixel[0], pixel[1], pixel[2]);
+    let (pixels, _) = image.pixels.as_chunks::<3>();
+    if pixels.len() < PARALLEL_PIXEL_THRESHOLD {
+        return pixels.iter().map(convert).collect();
     }
-    // `par_chunks_exact` is indexed, so collecting preserves pixel order.
-    image.pixels.par_chunks_exact(3).map(convert).collect()
+    // `par_iter` is indexed, so collecting preserves pixel order.
+    pixels.par_iter().map(convert).collect()
 }
 
 /// How far a [`simulate_video_with_progress`] run has got.

--- a/crates/eventcv-core/src/viz.rs
+++ b/crates/eventcv-core/src/viz.rs
@@ -783,7 +783,9 @@ mod tests {
         assert_eq!(pixel(&image, 0, 0), [68, 1, 84]);
         assert!(image
             .pixels
-            .chunks_exact(3)
-            .all(|rgb| rgb == pixel(&image, 0, 0)));
+            .as_chunks::<3>()
+            .0
+            .iter()
+            .all(|rgb| *rgb == pixel(&image, 0, 0)));
     }
 }

--- a/crates/eventcv-py/src/viewer.rs
+++ b/crates/eventcv-py/src/viewer.rs
@@ -203,7 +203,9 @@ fn mcts_cloud(frame: &EventFrame) -> Result<Vec<CloudPoint>, String> {
 fn point_set_cloud(points: &EventPointSet) -> Vec<CloudPoint> {
     points
         .data()
-        .chunks_exact(4)
+        .as_chunks::<4>()
+        .0
+        .iter()
         .map(|point| CloudPoint {
             x: f64::from(point[0]) * 2.0 - 1.0,
             y: 1.0 - f64::from(point[1]) * 2.0,

--- a/crates/eventcv-py/src/viewer/gpu.rs
+++ b/crates/eventcv-py/src/viewer/gpu.rs
@@ -1150,7 +1150,9 @@ fn rgb_to_rgba(rgb: &[u8]) -> Vec<u8> {
     // `extend_from_slice` (a length check plus a memcpy call for each 3-byte chunk) adds up at that
     // rate on cores with less headroom to hide it.
     let mut rgba = vec![0u8; rgb.len() / 3 * 4];
-    for (src, dst) in rgb.chunks_exact(3).zip(rgba.chunks_exact_mut(4)) {
+    let (sources, _) = rgb.as_chunks::<3>();
+    let (destinations, _) = rgba.as_chunks_mut::<4>();
+    for (src, dst) in sources.iter().zip(destinations.iter_mut()) {
         dst[0] = src[0];
         dst[1] = src[1];
         dst[2] = src[2];

--- a/crates/eventcv-py/src/viewer/roi.rs
+++ b/crates/eventcv-py/src/viewer/roi.rs
@@ -142,7 +142,8 @@ impl MaskEditor {
             return;
         }
         let preview = self.drag.as_ref().map(|drag| (self.shape(drag), drag.subtract));
-        for (index, pixel) in image.pixels.chunks_exact_mut(3).enumerate() {
+        let (pixels, _) = image.pixels.as_chunks_mut::<3>();
+        for (index, pixel) in pixels.iter_mut().enumerate() {
             let keep = match &preview {
                 Some((shape, true)) => self.mask[index] && !shape[index],
                 Some((shape, false)) => self.mask[index] || shape[index],
@@ -151,7 +152,7 @@ impl MaskEditor {
             if !keep {
                 // Halve the brightness and cast it red, so an excluded region still shows its
                 // events (you can see what you are cutting out) but never reads as kept.
-                pixel.copy_from_slice(&[pixel[0] / 2 + 48, pixel[1] / 3, pixel[2] / 3]);
+                *pixel = [pixel[0] / 2 + 48, pixel[1] / 3, pixel[2] / 3];
             }
         }
     }

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -105,6 +105,58 @@ class TextLoadTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             eventcv.load(path, sensor_size=(0, 4))
 
+    def test_scientific_notation_columns(self):
+        # N-CARS writes every `.txt` column in scientific notation; it has to read as the
+        # same events the plain integer spelling gives.
+        sci = self._write(
+            "3.000000000000000000e+01 4.000000000000000000e+01 "
+            "0.000000000000000000e+00 1.000000000000000000e+00\n",
+            "scientific.txt",
+        )
+        plain = self._write("30 40 0 1\n", "plain.txt")
+        options = dict(sensor_size=(120, 100), order="xytp", time_unit="us")
+
+        np.testing.assert_array_equal(
+            eventcv.load(sci, **options).numpy(), eventcv.load(plain, **options).numpy()
+        )
+
+    def test_scientific_notation_reads_the_same_with_or_without_time_unit(self):
+        # Whether `time_unit` is passed picks which parser runs, so the two have to agree.
+        path = self._write(
+            "3.000000e+01 4.000000e+01 5.000000e-01 1.000000e+00\n", "scientific.txt"
+        )
+        inferred = eventcv.load(path, sensor_size=(120, 100), order="xytp").numpy()
+        explicit = eventcv.load(
+            path, sensor_size=(120, 100), order="xytp", time_unit="seconds"
+        ).numpy()
+
+        np.testing.assert_array_equal(inferred, explicit)  # 0.5 s -> 500000 µs on both
+        np.testing.assert_array_equal(explicit[0], [30, 40, 500000, 1])
+
+    def test_coordinates_that_are_not_exact_integers_are_rejected(self):
+        # Reading x/y as floats to admit `3.0e+01` must not also admit `3.7` or `70000`,
+        # which a bare cast would silently turn into 3 and 65535 — on either parser.
+        for text in ("3.7 40 0 1\n", "70000 40 0 1\n", "-1 40 0 1\n"):
+            path = self._write(text)
+            for unit in (None, "us"):
+                with self.subTest(text=text, time_unit=unit):
+                    with self.assertRaisesRegex(ValueError, "invalid x"):
+                        eventcv.load(
+                            path, sensor_size=(120, 100), order="xytp", time_unit=unit
+                        )
+
+    def test_reader_slices_scientific_notation(self):
+        # `open()` indexes with one parser and slices with another; scientific notation used
+        # to index cleanly and then fail on every slice.
+        path = self._write(
+            "0.000000e+00 3.000000e+01 4.000000e+01 1.000000e+00\n"
+            "1.000000e+03 3.100000e+01 4.100000e+01 0.000000e+00\n"
+        )
+        reader = eventcv.open(path, sensor_size=(120, 100), time_unit="us")
+
+        self.assertEqual(reader.n_events, 2)
+        np.testing.assert_array_equal(reader.slice_count(0, 2).numpy()[:, 0], [30, 31])
+
     def test_missing_file_raises_file_not_found(self):
         with self.assertRaises(FileNotFoundError):
             eventcv.load("does-not-exist.txt", sensor_size=(4, 4))

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -405,60 +405,7 @@ class LoadTests(unittest.TestCase):
 
             with self.assertRaisesRegex(ValueError, "exceeds sensor size 640x480"):
                 eventcv.load(str(path))
-    def test_text_accepts_scientific_notation(self):
-        # N-CARS writes its `.txt` columns in scientific notation; the same events spelled as
-        # plain integers must load identically.
-        scientific = (
-            "3.000000000000000000e+01 4.000000000000000000e+01 "
-            "0.000000000000000000e+00 1.000000000000000000e+00\n"
-        )
-        with tempfile.TemporaryDirectory() as directory:
-            path = Path(directory) / "scientific.txt"
-            path.write_text(scientific)
-            events = eventcv.load(
-                str(path), sensor_size=(120, 100), order="xytp", time_unit="microseconds"
-            ).numpy()
 
-            plain = Path(directory) / "plain.txt"
-            plain.write_text("30 40 0 1\n")
-            expected = eventcv.load(
-                str(plain), sensor_size=(120, 100), order="xytp", time_unit="microseconds"
-            ).numpy()
-
-        np.testing.assert_array_equal(events, expected)
-
-    def test_explicit_time_unit_accepts_what_inference_does(self):
-        # The two paths diverged: omitting `time_unit` infers it from the timestamps and parsed
-        # these bytes, while passing it took a stricter path that rejected the x column.
-        scientific = (
-            "3.000000000000000000e+01 4.000000000000000000e+01 "
-            "0.000000000000000000e+00 1.000000000000000000e+00\n"
-        )
-        with tempfile.TemporaryDirectory() as directory:
-            path = Path(directory) / "scientific.txt"
-            path.write_text(scientific)
-            inferred = eventcv.load(
-                str(path), sensor_size=(120, 100), order="xytp"
-            ).numpy()
-            explicit = eventcv.load(
-                str(path), sensor_size=(120, 100), order="xytp", time_unit="seconds"
-            ).numpy()
-
-        # t is scaled by the unit, so only the coordinates and polarity are comparable.
-        np.testing.assert_array_equal(inferred[:, [0, 1, 3]], explicit[:, [0, 1, 3]])
-
-    def test_fractional_text_coordinate_raises_value_error(self):
-        # Reading x/y as floats to admit `3.0e+01` must not also admit `3.7`, which a bare cast
-        # would silently truncate to 3.
-        with tempfile.TemporaryDirectory() as directory:
-            path = Path(directory) / "fractional.txt"
-            path.write_text("3.7 40 0 1\n")
-
-            with self.assertRaisesRegex(ValueError, "x"):
-                eventcv.load(
-                    str(path), sensor_size=(120, 100), order="xytp",
-                    time_unit="microseconds",
-                )
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -405,7 +405,60 @@ class LoadTests(unittest.TestCase):
 
             with self.assertRaisesRegex(ValueError, "exceeds sensor size 640x480"):
                 eventcv.load(str(path))
+    def test_text_accepts_scientific_notation(self):
+        # N-CARS writes its `.txt` columns in scientific notation; the same events spelled as
+        # plain integers must load identically.
+        scientific = (
+            "3.000000000000000000e+01 4.000000000000000000e+01 "
+            "0.000000000000000000e+00 1.000000000000000000e+00\n"
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "scientific.txt"
+            path.write_text(scientific)
+            events = eventcv.load(
+                str(path), sensor_size=(120, 100), order="xytp", time_unit="microseconds"
+            ).numpy()
 
+            plain = Path(directory) / "plain.txt"
+            plain.write_text("30 40 0 1\n")
+            expected = eventcv.load(
+                str(plain), sensor_size=(120, 100), order="xytp", time_unit="microseconds"
+            ).numpy()
+
+        np.testing.assert_array_equal(events, expected)
+
+    def test_explicit_time_unit_accepts_what_inference_does(self):
+        # The two paths diverged: omitting `time_unit` infers it from the timestamps and parsed
+        # these bytes, while passing it took a stricter path that rejected the x column.
+        scientific = (
+            "3.000000000000000000e+01 4.000000000000000000e+01 "
+            "0.000000000000000000e+00 1.000000000000000000e+00\n"
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "scientific.txt"
+            path.write_text(scientific)
+            inferred = eventcv.load(
+                str(path), sensor_size=(120, 100), order="xytp"
+            ).numpy()
+            explicit = eventcv.load(
+                str(path), sensor_size=(120, 100), order="xytp", time_unit="seconds"
+            ).numpy()
+
+        # t is scaled by the unit, so only the coordinates and polarity are comparable.
+        np.testing.assert_array_equal(inferred[:, [0, 1, 3]], explicit[:, [0, 1, 3]])
+
+    def test_fractional_text_coordinate_raises_value_error(self):
+        # Reading x/y as floats to admit `3.0e+01` must not also admit `3.7`, which a bare cast
+        # would silently truncate to 3.
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "fractional.txt"
+            path.write_text("3.7 40 0 1\n")
+
+            with self.assertRaisesRegex(ValueError, "x"):
+                eventcv.load(
+                    str(path), sensor_size=(120, 100), order="xytp",
+                    time_unit="microseconds",
+                )
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description
Text loader rejects scientific notation when time_unit is specified

## Related Issue
@Event-LAB-Team
A proposed fix to the issue: #26 named "Text loader rejects scientific notation when time_unit is specified
"
 

## Checklist and questions
- [x] My code follows the style and [contribution guidelines](https://github.com/EventLAB-Team/eventcv/tree/main?tab=contributing-ov-file) of this project
- [x] If adding a new feature, I have created the relevant `test/` and have verified that it passes
- [x] I have made alterations to pre-existing functions