### PR TITLE
ros2 integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "advisory-lock"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6caee7d48f930f9ad3fc9546f8cbf843365da0c5b0ca4eee1d1ac3dd12d8f93"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,7 +132,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -146,6 +156,12 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android-activity"
@@ -188,10 +204,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arboard"
@@ -209,6 +275,21 @@ dependencies = [
  "windows-sys 0.59.0",
  "x11rb",
 ]
+
+[[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "array-init"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
 
 [[package]]
 name = "arrayref"
@@ -241,6 +322,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
 dependencies = [
  "libloading 0.8.9",
+]
+
+[[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -455,6 +575,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,7 +607,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0481a0e032742109b1133a095184ee93d88f3dc9e0d28a5d033dc77a073f44f"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.7.0",
 ]
 
 [[package]]
@@ -483,6 +615,15 @@ name = "bit-vec"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2c54ff287cfc0a34f38a6b832ea1bd8e448a330b3e40a50859e6488bee07f22"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -495,6 +636,9 @@ name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "block"
@@ -540,6 +684,24 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "piper",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "buddy_system_allocator"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7913f22349ffcfc6ca0ca9a656ec26cfbba538ed49c31a273dff2c5d1ea83d9"
+dependencies = [
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -688,6 +850,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.1",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -731,6 +916,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -739,8 +925,22 @@ version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -768,6 +968,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cobs"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+
+[[package]]
 name = "codespan-reporting"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,6 +988,12 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "com"
@@ -834,6 +1046,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const_format"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
+dependencies = [
+ "const_format_proc_macros",
+ "konst",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -844,6 +1083,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -862,7 +1111,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -875,7 +1124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "libc",
 ]
 
@@ -884,6 +1133,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -909,7 +1167,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -928,7 +1186,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -946,6 +1226,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -973,6 +1262,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "cursor-icon"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,10 +1300,122 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "digest"
@@ -1002,8 +1424,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1064,6 +1508,18 @@ name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
+
+[[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecolor"
@@ -1241,6 +1697,8 @@ dependencies = [
  "gif",
  "hdf5-metno",
  "hdf5-metno-sys",
+ "hiroz",
+ "hiroz-msgs",
  "libloading 0.9.0",
  "lz4",
  "ndarray",
@@ -1249,11 +1707,14 @@ dependencies = [
  "ort",
  "png",
  "pollster 0.3.0",
- "rand",
+ "rand 0.8.7",
  "rand_distr",
  "rayon",
  "rosbag",
+ "serde",
  "serde_json",
+ "tokio",
+ "tracing-subscriber",
  "wgpu",
  "zip",
  "zstd 0.13.3",
@@ -1274,6 +1735,18 @@ dependencies = [
  "rfd",
  "wgpu",
  "winit",
+]
+
+[[package]]
+name = "fastbloom"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
+dependencies = [
+ "foldhash 0.2.0",
+ "libm",
+ "portable-atomic",
+ "siphasher",
 ]
 
 [[package]]
@@ -1298,6 +1771,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1308,10 +1787,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "spin 0.9.9",
+]
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -1350,10 +1847,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-core"
-version = "0.3.32"
+name = "futures"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -1376,13 +1909,13 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1393,16 +1926,17 @@ checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1440,8 +1974,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1452,8 +1988,22 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1467,6 +2017,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "git-version"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad568aa3db0fcbc81f2f116137f263d7304f512a1209b35b85150d3ef88ad19"
+dependencies = [
+ "git-version-macro",
+]
+
+[[package]]
+name = "git-version-macro"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "gl_generator"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1476,6 +2046,12 @@ dependencies = [
  "log",
  "xml-rs",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "glow"
@@ -1563,11 +2139,38 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1687,12 +2290,185 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
+name = "hiroz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01faafa7d00a8a89d8f2d8eb3b35c1e7a72eca3d5205ec7d52f40b1cb6bde4c0"
+dependencies = [
+ "byteorder",
+ "clap",
+ "csv",
+ "dashmap",
+ "event-listener",
+ "flume",
+ "hiroz-cdr",
+ "hiroz-derive",
+ "hiroz-protocol",
+ "hiroz-schema",
+ "json5",
+ "parking_lot",
+ "paste",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "sha2",
+ "slab",
+ "strum",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+ "zenoh",
+ "zenoh-buffers",
+ "zenoh-ext",
+]
+
+[[package]]
+name = "hiroz-cdr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69398421bf7e64822904d8a4744186af65c56fce141756965c86ad27565c2e43"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "serde",
+ "thiserror 2.0.18",
+ "zenoh-buffers",
+]
+
+[[package]]
+name = "hiroz-codegen"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ead8754b67b3b6ee782825ea0b405bcc718d6f6b5d1352cf6e3013bd0771711"
+dependencies = [
+ "anyhow",
+ "hex",
+ "hiroz-schema",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "hiroz-derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b666d2b633c396be85316f0542fa6f4aa835aa871fe8a0ada3abf0ceb8aaead"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "hiroz-msgs"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdcda553a7f2a20d06f986082e8aa3773423c8099b06bdf3061e0d3a9aa9269f"
+dependencies = [
+ "anyhow",
+ "bytemuck",
+ "byteorder",
+ "glob",
+ "hiroz",
+ "hiroz-cdr",
+ "hiroz-codegen",
+ "serde",
+ "serde-big-array",
+ "serde_bytes",
+ "smart-default",
+ "zenoh-buffers",
+]
+
+[[package]]
+name = "hiroz-protocol"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eb54ca97b7899a8a21cc6fed0e1a4136b9f2df27b5729d816c2053451847279"
+dependencies = [
+ "zenoh",
+]
+
+[[package]]
+name = "hiroz-schema"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce82f490ac00135896d594fa84f673e02b11a084d9280a6c5881e50473aa497"
+dependencies = [
+ "hex",
+ "serde",
+ "serde_json",
+ "sha2",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "http"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "humantime"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core 0.58.0",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1779,6 +2555,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1810,12 +2592,25 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1825,6 +2620,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "io-kit-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617ee6cf8e3f66f3b4ea67a4058564628cde41901316e19f559e14c7c72c5e7b"
+dependencies = [
+ "core-foundation-sys",
+ "mach2",
+]
+
+[[package]]
+name = "ipnetwork"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1839,6 +2653,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1848,10 +2668,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "jni"
@@ -1933,6 +2815,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "keyed-set"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89d255a6b6ecd77bb93ce91de984d7039bff7503f500eb4851a1269732f22baf"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "khronos-egl"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1948,6 +2859,36 @@ name = "khronos_api"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin 0.9.9",
+]
+
+[[package]]
+name = "leb128"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52"
 
 [[package]]
 name = "libc"
@@ -2051,10 +2992,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "lockfree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74ee94b5ad113c7cb98c5a040f783d0952ee4fe100993881d1673c2cb002dd23"
+dependencies = [
+ "owned-alloc",
+]
+
+[[package]]
 name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4"
@@ -2076,6 +3041,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4_flex"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b8c72594ac26bfd34f2d99dfced2edfaddfe8a476e3ff2ca0eb293d925c4f83"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "lzf-sys"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2085,12 +3059,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -2143,6 +3135,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2150,6 +3148,31 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "mio-serial"
+version = "5.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d4ba3f20276f21b7cad3f1b54c97489cf096a3894fd627cc6951cb3abdd4c60"
+dependencies = [
+ "log",
+ "mio",
+ "nix 0.31.3",
+ "serialport",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2164,13 +3187,22 @@ dependencies = [
  "cfg_aliases 0.1.1",
  "codespan-reporting",
  "hexf-parse",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "rustc-hash 1.1.0",
  "spirv",
  "termcolor",
  "thiserror 1.0.69",
  "unicode-xid",
+]
+
+[[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2251,6 +3283,17 @@ checksum = "8ba7c9f18cdc800a16d47977472c5c75e96965eef57dbf39d37e937f390d6fef"
 
 [[package]]
 name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
@@ -2263,10 +3306,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "libc",
+]
+
+[[package]]
+name = "no-std-net"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
+
+[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nonempty-collections"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e216d0e8cf9d54fa66e5780f6e1d5dc96d1c1b3c25aeba3b6758548bcbbd8b9d"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "npyz"
@@ -2293,6 +3373,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2300,6 +3389,22 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.7",
+ "smallvec",
+ "zeroize",
 ]
 
 [[package]]
@@ -2327,6 +3432,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2334,6 +3449,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -2655,16 +3780,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orbclient"
@@ -2704,6 +3856,12 @@ name = "ort-sys"
 version = "2.0.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf211e3776eea6aec988552fa118dd746d70e1b1e5e244058d1c98015f3e5872"
+
+[[package]]
+name = "owned-alloc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30fceb411f9a12ff9222c5f824026be368ff15dc2f13468d850c7d3f502205d6"
 
 [[package]]
 name = "owned_ttf_parser"
@@ -2750,7 +3908,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -2770,6 +3928,25 @@ dependencies = [
  "hmac",
  "password-hash",
  "sha2",
+]
+
+[[package]]
+name = "pem"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d354a98a3d1251555de99e8fdd8afda05573c31b82f59063a7b0a29b5527f120"
+dependencies = [
+ "base64 0.23.1",
+ "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -2822,6 +3999,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+ "serde",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2859,6 +4091,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2869,6 +4122,38 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "pnet_base"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc190d4067df16af3aba49b3b74c469e611cad6314676eaf1157f31aa0fb2f7"
+dependencies = [
+ "no-std-net",
+]
+
+[[package]]
+name = "pnet_datalink"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79e70ec0be163102a332e1d2d5586d362ad76b01cec86f830241f2b6452a7b7"
+dependencies = [
+ "ipnetwork",
+ "libc",
+ "pnet_base",
+ "pnet_sys",
+ "winapi",
+]
+
+[[package]]
+name = "pnet_sys"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d4643d3d4db6b08741050c2f3afa9a892c4244c085a72fcda93c9c2c9a00f4b"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "png"
@@ -2955,6 +4240,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2998,6 +4293,29 @@ name = "profiling"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
+
+[[package]]
+name = "prometheus-client"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cca3d75b4566b9a29fe1ed623587fb058e826eb329a0be4b7c4da1ebb2d7a6ca"
+dependencies = [
+ "dtoa",
+ "itoa",
+ "parking_lot",
+ "prometheus-client-derive-encode",
+]
+
+[[package]]
+name = "prometheus-client-derive-encode"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9adf1691c04c0a5ff46ff8f262b58beb07b0dbb61f96f9f54f6cbd82106ed87f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "py_literal"
@@ -3089,6 +4407,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases 0.2.1",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "socket2 0.6.5",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
+dependencies = [
+ "bytes",
+ "fastbloom",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases 0.2.1",
+ "libc",
+ "once_cell",
+ "socket2 0.6.5",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3104,6 +4480,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3111,7 +4493,18 @@ checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3121,7 +4514,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3134,13 +4527,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_distr"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.7",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3182,6 +4590,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.14.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8774e05a7d0de114588e6a28fe7e71694b82614ed569d86d8b389dfbc98b8ad8"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3206,6 +4628,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
 dependencies = [
  "bitflags 2.13.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3271,6 +4724,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "ringbuffer-spsc"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3e7aa0a681b232e7cd7f856a53b10603df88ca74b79a8d8088845185492e35"
+dependencies = [
+ "array-init",
+ "crossbeam",
+]
+
+[[package]]
+name = "rlimit"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7043b63bd0cd1aaa628e476b80e6d4023a3b50eb32789f2728908107bd0c793a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "ron"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81116b9531d61eabc41aeb228e4b6b2435bcca3233b98cf3b3077d4e6e9debb3"
+dependencies = [
+ "bitflags 2.13.0",
+ "once_cell",
+ "serde",
+ "serde_derive",
+ "typeid",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rosbag"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3282,6 +4782,26 @@ dependencies = [
  "log",
  "lz4",
  "memmap2",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3316,6 +4836,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3342,10 +4871,100 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3354,6 +4973,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
+dependencies = [
+ "dyn-clone",
+ "either",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3382,6 +5048,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3395,6 +5094,25 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3415,6 +5133,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3442,13 +5171,86 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
+dependencies = [
+ "base64 0.22.1",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "jiff",
+ "schemars 0.9.0",
+ "schemars 1.2.2",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8705578779c2b6bd90d84d66eb2e206b708b1a4d7b9f17641b293545bf1c7e46"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "serialport"
+version = "4.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a2f4ac56b5d3af3c40fbbee17be96d532cba02fa5853926aacdb77d926272ab"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "io-kit-sys",
+ "mach2",
+ "nix 0.26.4",
+ "scopeguard",
+ "unescaper",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3459,8 +5261,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
+]
+
+[[package]]
+name = "sha2-const-stable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f179d4e11094a893b82fff208f74d448a7512f99f5a0acbd5c679b705f83ed9"
+
+[[package]]
+name = "sha3"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+dependencies = [
+ "digest",
+ "keccak",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "shellexpand"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
+dependencies = [
+ "dirs",
 ]
 
 [[package]]
@@ -3477,6 +5313,16 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3502,6 +5348,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3521,6 +5373,17 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "smart-default"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "smithay-client-toolkit"
@@ -3595,12 +5458,91 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spin"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
+
+[[package]]
 name = "spirv"
 version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
 dependencies = [
  "bitflags 2.13.0",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "stabby"
+version = "72.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d53d2428934c46277fafd2d41e39357595aa1e47954c75db2b14ed90632f3cc"
+dependencies = [
+ "rustversion",
+ "stabby-abi",
+]
+
+[[package]]
+name = "stabby-abi"
+version = "72.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f375eae680bb54203ee5e47d4cd2ae7b79c0a79ed90919279f38f500ad53f190"
+dependencies = [
+ "rustc_version",
+ "rustversion",
+ "sha2-const-stable",
+ "stabby-macros",
+]
+
+[[package]]
+name = "stabby-macros"
+version = "72.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea664671a576c5f7e32fee291ac123d82af5e92b0689beb3555347c00c76eef1"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3616,10 +5558,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "static_init"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bae1df58c5fea7502e8e352ec26b5579f6178e1fdb311e088580c980dee25ed"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg_aliases 0.2.1",
+ "libc",
+ "parking_lot",
+ "parking_lot_core",
+ "static_init_macro",
+ "winapi",
+]
+
+[[package]]
+name = "static_init_macro"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1389c88ddd739ec6d3f8f83343764a0e944cd23cfbf126a9796a714b0b6edd6f"
+dependencies = [
+ "cfg_aliases 0.1.1",
+ "memchr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "subtle"
@@ -3670,6 +5667,12 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
+
+[[package]]
+name = "talc"
+version = "4.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ae828aa394de34c7de08f522d1b86bd1c182c668d27da69caadda00590f26d"
 
 [[package]]
 name = "target-lexicon"
@@ -3740,6 +5743,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread-priority"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe075d7053dae61ac5413a34ea7d4913b6e6207844fd726bdd858b37ff72bf5"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3750,6 +5776,7 @@ dependencies = [
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -3757,6 +5784,16 @@ name = "time-core"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tiny-skia"
@@ -3804,6 +5841,147 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tls-listener"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1461056cc1ef47003f7ee16e4cef3741068d4c7f6b627bfce49b7c00c120a530"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
+name = "token-cell"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb48920ae769b58126c8c93269805011c793201f95fde28b479b81a9a531bbde"
+dependencies = [
+ "paste",
+ "portable-atomic",
+ "rustversion",
+]
+
+[[package]]
+name = "tokio"
+version = "1.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2 0.6.5",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-serial"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd00f5f8b1e01c3e5afccd9e42ed80c2ad2df6d007877f29f8592c62e69cd116"
+dependencies = [
+ "cfg-if",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "mio-serial",
+ "serialport",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3818,10 +5996,10 @@ version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
- "indexmap",
- "toml_datetime",
+ "indexmap 2.14.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -3830,8 +6008,14 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.3",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tracing"
@@ -3863,6 +6047,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -3872,6 +6099,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.7",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
+]
+
+[[package]]
 name = "type-map"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3879,6 +6134,12 @@ checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
 dependencies = [
  "rustc-hash 2.1.2",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
@@ -3901,6 +6162,29 @@ dependencies = [
  "memoffset",
  "tempfile",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "uhlc"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62a645e3e4e6c85b7abe49b086aa3204119431f42b6123b0070419fb6e9d24e"
+dependencies = [
+ "humantime",
+ "lazy_static",
+ "log",
+ "rand 0.8.7",
+ "serde",
+ "spin 0.10.1",
+]
+
+[[package]]
+name = "unescaper"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7285e83a80ce76f5e7bce79fa41f68d78ba62d1003cf27bf748ab24413808cf4"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3928,6 +6212,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "unzip-n"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b5bb2756c16fb66f80cfbf5fb0e0c09a7001e739f453c9ec241b9c8b1556fda"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3940,16 +6247,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
+dependencies = [
+ "getrandom 0.4.3",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "validated_struct"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "869a93e8a7286e339e1128630051d82babbcd75d585975af07b9f3327220e60e"
+dependencies = [
+ "json5",
+ "serde",
+ "serde_json",
+ "validated_struct_macros",
+]
+
+[[package]]
+name = "validated_struct_macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c44ce98e7227a04eeb4cf9c784109a5c9710e54849ceb4f09f8597247897f1e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "unzip-n",
+]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -4209,6 +6575,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4246,11 +6630,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0348c840d1051b8e86c3bcd31206080c5e71e5933dabd79be1ce732b0b2f089a"
 dependencies = [
  "arrayvec",
- "bit-vec",
+ "bit-vec 0.7.0",
  "bitflags 2.13.0",
  "cfg_aliases 0.1.1",
  "document-features",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "naga",
  "once_cell",
@@ -4327,6 +6711,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
+name = "win-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b7b128a98c1cfa201b09eb49ba285887deb3cbe7466a98850eb1adabb452be5"
+dependencies = [
+ "windows 0.34.0",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4356,6 +6749,19 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45296b64204227616fdbf2614cefa4c236b98ee64dfaaaa435207ed99fe7829f"
+dependencies = [
+ "windows_aarch64_msvc 0.34.0",
+ "windows_i686_gnu 0.34.0",
+ "windows_i686_msvc 0.34.0",
+ "windows_x86_64_gnu 0.34.0",
+ "windows_x86_64_msvc 0.34.0",
+]
 
 [[package]]
 name = "windows"
@@ -4480,13 +6886,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -4497,9 +6903,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4515,9 +6933,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4530,6 +6960,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4552,7 +6988,7 @@ dependencies = [
  "calloop 0.13.0",
  "cfg_aliases 0.2.1",
  "concurrent-queue",
- "core-foundation",
+ "core-foundation 0.9.4",
  "core-graphics",
  "cursor-icon",
  "dpi",
@@ -4588,6 +7024,12 @@ dependencies = [
  "x11rb",
  "xkbcommon-dl",
 ]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
@@ -4654,6 +7096,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "xcursor"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4695,6 +7155,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec 0.9.1",
+ "time",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4715,6 +7185,19 @@ dependencies = [
  "quote",
  "syn 2.0.118",
  "synstructure",
+]
+
+[[package]]
+name = "z-serial"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1660dfc9f90480610f94c285a9a967b49cd2f57b3b1267d9bd7fd5d4f57c36c8"
+dependencies = [
+ "cobs",
+ "futures",
+ "log",
+ "tokio",
+ "tokio-serial",
 ]
 
 [[package]]
@@ -4739,9 +7222,9 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "hex",
- "nix",
+ "nix 0.29.0",
  "ordered-stream",
- "rand",
+ "rand 0.8.7",
  "serde",
  "serde_repr",
  "sha1",
@@ -4817,6 +7300,609 @@ dependencies = [
 ]
 
 [[package]]
+name = "zenoh"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f7ad636296bfdb8a86bbbc9bae1b6a57f0e77b715769f99885ca2ca2368c73a"
+dependencies = [
+ "ahash",
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "const_format",
+ "flate2",
+ "flume",
+ "futures",
+ "git-version",
+ "itertools 0.14.0",
+ "json5",
+ "lazy_static",
+ "nonempty-collections",
+ "once_cell",
+ "petgraph",
+ "phf",
+ "rand 0.8.7",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uhlc",
+ "vec_map",
+ "zenoh-buffers",
+ "zenoh-codec",
+ "zenoh-collections",
+ "zenoh-config",
+ "zenoh-core",
+ "zenoh-keyexpr",
+ "zenoh-link",
+ "zenoh-link-commons",
+ "zenoh-macros",
+ "zenoh-plugin-trait",
+ "zenoh-protocol",
+ "zenoh-result",
+ "zenoh-runtime",
+ "zenoh-shm",
+ "zenoh-sync",
+ "zenoh-task",
+ "zenoh-transport",
+ "zenoh-util",
+]
+
+[[package]]
+name = "zenoh-buffers"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a81e52197e18bc75587c566df732726aee6e0a1c8779d7a2ff609f461f6b1a07"
+dependencies = [
+ "zenoh-collections",
+]
+
+[[package]]
+name = "zenoh-codec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b792ce46854f252af31869030224c2da6bd9d72a1cd2812e29b457444a07b1"
+dependencies = [
+ "rand 0.8.7",
+ "tracing",
+ "uhlc",
+ "zenoh-buffers",
+ "zenoh-protocol",
+ "zenoh-shm",
+]
+
+[[package]]
+name = "zenoh-collections"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b897fae0ddce178e3e58d3bb9ca131dd2a301dd869ebded37d9e1f3784aac0"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "zenoh-config"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b39224e3029571e0572f88590eb9078bcd60dedc6381ad1a5c8ad5fb7a474bf"
+dependencies = [
+ "json5",
+ "nonempty-collections",
+ "num_cpus",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "serde_yaml",
+ "toml",
+ "tracing",
+ "uhlc",
+ "validated_struct",
+ "zenoh-core",
+ "zenoh-keyexpr",
+ "zenoh-macros",
+ "zenoh-protocol",
+ "zenoh-result",
+ "zenoh-util",
+]
+
+[[package]]
+name = "zenoh-core"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9335e8f6509fcbec68a073372c13a69ba90c3a284a86427257607d75586b6344"
+dependencies = [
+ "lazy_static",
+ "tokio",
+ "zenoh-result",
+ "zenoh-runtime",
+]
+
+[[package]]
+name = "zenoh-crypto"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b496e8c984260c4d80ce58b42956081dc8656f0b875766e5ae0f8e39510fdee"
+dependencies = [
+ "aes",
+ "hmac",
+ "rand 0.8.7",
+ "rand_chacha",
+ "sha3",
+ "zenoh-result",
+]
+
+[[package]]
+name = "zenoh-ext"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fa8d798c8bc3aa0a4f769d0b67a1219bb2b9bfb3a173fce0b063071808b86a"
+dependencies = [
+ "bincode",
+ "flume",
+ "futures",
+ "leb128",
+ "lru",
+ "serde",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uhlc",
+ "zenoh",
+ "zenoh-macros",
+ "zenoh-util",
+]
+
+[[package]]
+name = "zenoh-keyexpr"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af891f8d9f52c3e8617712b65b08fa9ae02f1f1b57e2739ff194bb65df1255df"
+dependencies = [
+ "getrandom 0.2.17",
+ "hashbrown 0.16.1",
+ "keyed-set",
+ "rand 0.8.7",
+ "schemars 1.2.2",
+ "serde",
+ "token-cell",
+ "zenoh-result",
+]
+
+[[package]]
+name = "zenoh-link"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04f796c9df0ef7736d140363507498d8c5d0acf621c158113f122aa992979d3d"
+dependencies = [
+ "zenoh-config",
+ "zenoh-link-commons",
+ "zenoh-link-quic",
+ "zenoh-link-quic_datagram",
+ "zenoh-link-serial",
+ "zenoh-link-tcp",
+ "zenoh-link-tls",
+ "zenoh-link-udp",
+ "zenoh-link-unixsock_stream",
+ "zenoh-link-ws",
+ "zenoh-protocol",
+ "zenoh-result",
+]
+
+[[package]]
+name = "zenoh-link-commons"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd110109f4f89450491bd8942152020f632eb86d8fac10349a186185f654873"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "flume",
+ "futures",
+ "quinn",
+ "quinn-proto",
+ "rcgen",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "secrecy",
+ "serde",
+ "socket2 0.5.10",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "webpki-roots",
+ "x509-parser",
+ "zenoh-buffers",
+ "zenoh-codec",
+ "zenoh-config",
+ "zenoh-core",
+ "zenoh-protocol",
+ "zenoh-result",
+ "zenoh-runtime",
+ "zenoh-util",
+]
+
+[[package]]
+name = "zenoh-link-quic"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1038b5c97aeca14bbba31d6bed629bd2d354488850c27eddde07726e90ce9a48"
+dependencies = [
+ "async-trait",
+ "rustls-webpki",
+ "time",
+ "tracing",
+ "zenoh-core",
+ "zenoh-link-commons",
+ "zenoh-link-quic_datagram",
+ "zenoh-protocol",
+ "zenoh-result",
+]
+
+[[package]]
+name = "zenoh-link-quic_datagram"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97b2cddd28955877b7eceedfaf09c801aac31ab8f0cac32c936f31358f5af133"
+dependencies = [
+ "async-trait",
+ "rustls-webpki",
+ "time",
+ "tokio-util",
+ "tracing",
+ "zenoh-core",
+ "zenoh-link-commons",
+ "zenoh-protocol",
+ "zenoh-result",
+]
+
+[[package]]
+name = "zenoh-link-serial"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcef77379116fefdb3b538731df649642c3cdb9a4d950bda4f587b360c35abc"
+dependencies = [
+ "async-trait",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+ "z-serial",
+ "zenoh-core",
+ "zenoh-link-commons",
+ "zenoh-protocol",
+ "zenoh-result",
+ "zenoh-runtime",
+]
+
+[[package]]
+name = "zenoh-link-tcp"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4801cc6fb608b5069f3ea6b82484c5f727019764e90e14838fe6930a9dffd9a1"
+dependencies = [
+ "async-trait",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "zenoh-config",
+ "zenoh-core",
+ "zenoh-link-commons",
+ "zenoh-protocol",
+ "zenoh-result",
+]
+
+[[package]]
+name = "zenoh-link-tls"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a123220c7aedf285cfeaaaf2f05d88787a164a92fa5c64c09156b861feb16134"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "secrecy",
+ "socket2 0.5.10",
+ "time",
+ "tls-listener",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tracing",
+ "webpki-roots",
+ "x509-parser",
+ "zenoh-config",
+ "zenoh-core",
+ "zenoh-link-commons",
+ "zenoh-protocol",
+ "zenoh-result",
+ "zenoh-runtime",
+]
+
+[[package]]
+name = "zenoh-link-udp"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6785a0b6f0b94131c002a8358aaef3eb99f5ab0e0cd444f28d1f1fac38bd4091"
+dependencies = [
+ "async-trait",
+ "libc",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "windows-sys 0.61.2",
+ "zenoh-buffers",
+ "zenoh-core",
+ "zenoh-link-commons",
+ "zenoh-link-quic_datagram",
+ "zenoh-protocol",
+ "zenoh-result",
+ "zenoh-sync",
+ "zenoh-util",
+]
+
+[[package]]
+name = "zenoh-link-unixsock_stream"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e000c7d101a3d2e5e3350a19ead2f7914276583d9d3a5787fde005465a1271d7"
+dependencies = [
+ "async-trait",
+ "nix 0.29.0",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+ "zenoh-core",
+ "zenoh-link-commons",
+ "zenoh-protocol",
+ "zenoh-result",
+ "zenoh-runtime",
+]
+
+[[package]]
+name = "zenoh-link-ws"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8a5dc8ab07d0ccb46b187f58b9ee5e38a1cacaaf780ad38398f6c2669dfb53"
+dependencies = [
+ "async-trait",
+ "futures-util",
+ "tokio",
+ "tokio-tungstenite",
+ "tokio-util",
+ "tracing",
+ "url",
+ "zenoh-core",
+ "zenoh-link-commons",
+ "zenoh-protocol",
+ "zenoh-result",
+ "zenoh-runtime",
+ "zenoh-util",
+]
+
+[[package]]
+name = "zenoh-macros"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c813ccde166cf0527402d46615257e0d152140e66f8ecd685721f9399251407"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "zenoh-keyexpr",
+]
+
+[[package]]
+name = "zenoh-plugin-trait"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95cd9d698675a5b2f3e958a35df56f6d60f0388669158055b436c0cbe5357ad8"
+dependencies = [
+ "git-version",
+ "libloading 0.8.9",
+ "serde",
+ "stabby",
+ "tracing",
+ "zenoh-config",
+ "zenoh-keyexpr",
+ "zenoh-macros",
+ "zenoh-result",
+ "zenoh-util",
+]
+
+[[package]]
+name = "zenoh-protocol"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce5505e2569421d3cb6792d4b3d9a6589d04add3bf34c0a7c37c03c2573b79ad"
+dependencies = [
+ "const_format",
+ "rand 0.8.7",
+ "serde",
+ "uhlc",
+ "zenoh-buffers",
+ "zenoh-keyexpr",
+ "zenoh-macros",
+ "zenoh-result",
+]
+
+[[package]]
+name = "zenoh-result"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf23203517d6dfe04393c42053093c7cffd9e385015e21c85dafaff9a342cccf"
+dependencies = [
+ "anyhow",
+]
+
+[[package]]
+name = "zenoh-runtime"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddf72c7310a090b0b22496649274661de8a17ca0d0674af8f72f184a3ed78664"
+dependencies = [
+ "lazy_static",
+ "ron",
+ "serde",
+ "tokio",
+ "tracing",
+ "zenoh-macros",
+ "zenoh-result",
+]
+
+[[package]]
+name = "zenoh-shm"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8f49ff9d36be3fdeada23103c5ba10d6e7159269bd8b07fb744448005fb5734"
+dependencies = [
+ "advisory-lock",
+ "async-trait",
+ "buddy_system_allocator",
+ "crossbeam-channel",
+ "crossbeam-queue",
+ "nix 0.29.0",
+ "num-traits",
+ "rand 0.8.7",
+ "rlimit",
+ "stabby",
+ "static_assertions",
+ "static_init",
+ "talc",
+ "thread-priority",
+ "tokio",
+ "tracing",
+ "win-sys",
+ "winapi",
+ "zenoh-buffers",
+ "zenoh-core",
+ "zenoh-macros",
+ "zenoh-result",
+]
+
+[[package]]
+name = "zenoh-stats"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f610d551359e0d8864138d4c4c11ed8e3c9f6991717f4eef198ab323b4ff01f4"
+dependencies = [
+ "ahash",
+ "prometheus-client",
+ "serde_json",
+ "smallvec",
+ "zenoh-keyexpr",
+ "zenoh-protocol",
+]
+
+[[package]]
+name = "zenoh-sync"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9792a8fa9b0f30ebabd3e6b278441178b6832462e959388aa18f92a93527935b"
+dependencies = [
+ "arc-swap",
+ "event-listener",
+ "futures",
+ "tokio",
+ "zenoh-buffers",
+ "zenoh-collections",
+ "zenoh-core",
+]
+
+[[package]]
+name = "zenoh-task"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbb419757b0c6e824bebf34959302e6edf5a7caea4e725de88007a56f3ba4d4d"
+dependencies = [
+ "futures",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "zenoh-core",
+ "zenoh-runtime",
+]
+
+[[package]]
+name = "zenoh-transport"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc431ec1c066d7047c601ae4b4d4a359882c5464cd9c4ff3fe905ff6e10017af"
+dependencies = [
+ "async-trait",
+ "crossbeam-utils",
+ "flume",
+ "futures",
+ "lazy_static",
+ "lockfree",
+ "lz4_flex",
+ "rand 0.8.7",
+ "ringbuffer-spsc",
+ "rsa",
+ "serde",
+ "sha3",
+ "static_init",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "zenoh-buffers",
+ "zenoh-codec",
+ "zenoh-config",
+ "zenoh-core",
+ "zenoh-crypto",
+ "zenoh-link",
+ "zenoh-link-commons",
+ "zenoh-protocol",
+ "zenoh-result",
+ "zenoh-runtime",
+ "zenoh-shm",
+ "zenoh-stats",
+ "zenoh-sync",
+ "zenoh-task",
+ "zenoh-util",
+]
+
+[[package]]
+name = "zenoh-util"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f99b13044636f453bcb49ca520db4b1400c8e444fdf578e63a1aad0ed9004e0"
+dependencies = [
+ "async-trait",
+ "const_format",
+ "flume",
+ "home",
+ "humantime",
+ "lazy_static",
+ "libc",
+ "libloading 0.8.9",
+ "pnet_datalink",
+ "schemars 1.2.2",
+ "serde",
+ "serde_json",
+ "shellexpand",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "winapi",
+ "zenoh-core",
+ "zenoh-result",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4856,6 +7942,12 @@ dependencies = [
  "syn 2.0.118",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/crates/eventcv-core/Cargo.toml
+++ b/crates/eventcv-core/Cargo.toml
@@ -108,6 +108,17 @@ criterion = { version = "0.5", default-features = false, features = ["cargo_benc
 # The ROS 2 example turns this on with RUST_LOG=…; hiroz and zenoh both log through `tracing`.
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+# The ROS 2 examples do not compile without the module they exercise, and
+# `cargo test` builds every example — so they declare what they need rather
+# than breaking a default-feature build.
+[[example]]
+name = "ros2_node"
+required-features = ["ros2"]
+
+[[example]]
+name = "hz_probe"
+required-features = ["ros2"]
+
 [[bench]]
 name = "pipeline"
 harness = false

--- a/crates/eventcv-core/Cargo.toml
+++ b/crates/eventcv-core/Cargo.toml
@@ -91,10 +91,22 @@ wgpu = { version = "22", optional = true }
 pollster = { version = "0.3", optional = true }   # block on wgpu's async device/adapter requests
 bytemuck = { version = "1", optional = true, features = ["derive"] }
 
+# Optional: ROS 2 publish/subscribe over Zenoh. `hiroz` is a ROS 2 stack in pure Rust, so this
+# links no ROS libraries and needs no ROS installation to build or to run -- the reason it is here
+# rather than `rclrs` or `r2r`, either of which would put the integration in a separate,
+# colcon-built package that could not ship in the wheel. Pinned exactly: hiroz is young.
+# The distro feature decides the key-expression and type-hash convention on the wire.
+hiroz = { version = "=0.2.0", optional = true, default-features = false, features = ["rolling", "rmw-zenoh", "config-builders"] }
+hiroz-msgs = { version = "=0.2.0", optional = true }
+serde = { version = "1", optional = true, features = ["derive"] }
+tokio = { version = "1", optional = true, features = ["rt-multi-thread"] }
+
 [dev-dependencies]
 # Benchmarks only. `html_reports` is off to keep the dependency tree small — the terminal output
 # carries the numbers, and the plots need gnuplot or a heavier plotting stack.
 criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
+# The ROS 2 example turns this on with RUST_LOG=…; hiroz and zenoh both log through `tracing`.
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [[bench]]
 name = "pipeline"
@@ -111,6 +123,10 @@ onnx = ["dep:ort", "dep:libloading"]
 # GPU compute (`Device::Gpu`). Off by default: the CPU path is the reference implementation and
 # stays the default at run time even when this is built in.
 gpu = ["dep:wgpu", "dep:pollster", "dep:bytemuck"]
+# ROS 2 publish/subscribe. Off by default: a wheel that nobody asked to speak ROS 2 should not
+# carry a Zenoh stack. Interoperates with ROS 2 running `rmw_zenoh_cpp`; a DDS deployment needs
+# `zenoh-bridge-ros2dds` in between.
+ros2 = ["dep:hiroz", "dep:hiroz-msgs", "dep:serde", "dep:tokio"]
 
 # docs.rs builds with default features (hdf5 off), so it never has to compile libhdf5
 # from source — the API surface is identical, and the build stays fast and network-free.

--- a/crates/eventcv-core/examples/aedat_check.rs
+++ b/crates/eventcv-core/examples/aedat_check.rs
@@ -1,0 +1,20 @@
+//! The parallel packet path must equal the sequential one, event for event.
+use eventcv_core::io::{open_aedat4_slice, read_aedat4, LoadOptions, SliceSource};
+fn main() {
+    let path = std::env::args().nth(1).unwrap();
+    let o = LoadOptions::default();
+    let src = open_aedat4_slice(&path, &o).unwrap();
+    let (lo, hi) = src.time_span();
+    let par = read_aedat4(&path, &o).unwrap();          // parallel slice_index
+    let seq = src.slice_time(lo, hi + 1).unwrap();      // sequential, packet by packet
+    println!("parallel {} events, sequential {} events", par.len(), seq.len());
+    assert_eq!(par.len(), seq.len(), "count");
+    assert_eq!(par.xs(), seq.xs(), "x");
+    assert_eq!(par.ys(), seq.ys(), "y");
+    assert_eq!(par.ts(), seq.ts(), "t");
+    assert_eq!(par.ps(), seq.ps(), "p");
+    let sorted = par.ts().windows(2).all(|w| w[0] <= w[1]);
+    println!("timestamps non-decreasing: {sorted}");
+    assert!(sorted);
+    println!("IDENTICAL");
+}

--- a/crates/eventcv-core/examples/decode_bench.rs
+++ b/crates/eventcv-core/examples/decode_bench.rs
@@ -1,0 +1,40 @@
+//! Decode-throughput microbenchmark: `cargo run --release --example decode_bench -- <files...>`
+use std::time::Instant;
+use eventcv_core::io::{read_aedat4, read_raw, open_raw_slice, LoadOptions};
+
+fn bench<T>(label: &str, reps: u32, mut f: impl FnMut() -> T) -> f64 {
+    f();
+    let mut best = f64::MAX;
+    let mut all = Vec::new();
+    for _ in 0..reps {
+        let t0 = Instant::now();
+        let _ = f();
+        let ms = t0.elapsed().as_secs_f64() * 1e3;
+        best = best.min(ms);
+        all.push(ms);
+    }
+    all.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let med = all[all.len() / 2];
+    println!("  {label:<28} median {med:8.2} ms   min {best:8.2} ms");
+    med
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let reps: u32 = std::env::var("REPS").ok().and_then(|v| v.parse().ok()).unwrap_or(7);
+    let opts = LoadOptions::default();
+    for path in &args {
+        println!("{path}");
+        if path.ends_with(".raw") {
+            let n = read_raw(path, &opts).unwrap().len();
+            let idx = bench("open_raw_slice (index pass)", reps, || open_raw_slice(path, &opts).unwrap());
+            let all = bench("read_raw (index + build)", reps, || read_raw(path, &opts).unwrap());
+            println!("  {n} events -> {:.1} Mev/s eager, materialise = {:.2} ms",
+                     n as f64 / all * 1e-3, all - idx);
+        } else if path.ends_with(".aedat4") {
+            let n = read_aedat4(path, &opts).unwrap().len();
+            let all = bench("read_aedat4", reps, || read_aedat4(path, &opts).unwrap());
+            println!("  {n} events -> {:.1} Mev/s", n as f64 / all * 1e-3);
+        }
+    }
+}

--- a/crates/eventcv-core/examples/decode_check.rs
+++ b/crates/eventcv-core/examples/decode_check.rs
@@ -1,0 +1,18 @@
+//! Correctness check: the single-pass eager read must equal the indexed slice, event for event.
+use eventcv_core::io::{open_raw_slice, read_raw, LoadOptions};
+use eventcv_core::io::SliceSource;
+fn main() {
+    let path = std::env::args().nth(1).unwrap();
+    let o = LoadOptions::default();
+    let fast = read_raw(&path, &o).unwrap();
+    let src = open_raw_slice(&path, &o).unwrap();
+    let slow = src.slice_index(0, src.n_events()).unwrap();
+    println!("fast {} events, slow {} events", fast.len(), slow.len());
+    assert_eq!(fast.len(), slow.len(), "event count differs");
+    assert_eq!(fast.xs(), slow.xs(), "x differs");
+    assert_eq!(fast.ys(), slow.ys(), "y differs");
+    assert_eq!(fast.ts(), slow.ts(), "t differs");
+    assert_eq!(fast.ps(), slow.ps(), "p differs");
+    assert_eq!(fast.sensor_size(), slow.sensor_size(), "sensor size differs");
+    println!("IDENTICAL");
+}

--- a/crates/eventcv-core/examples/hz_probe.rs
+++ b/crates/eventcv-core/examples/hz_probe.rs
@@ -1,0 +1,62 @@
+//! Reproducer for the one direction of ROS 2 interop that does not work.
+//!
+//! `rmw_zenoh_cpp` 0.12.0 publishes any message carrying a `uint8[]` field through its new buffer
+//! endpoints (its liveliness token gains a `backends:cpu` segment), and a subscriber that does not
+//! advertise a compatible backend receives nothing. `hiroz` 0.2.0 does not advertise one.
+//!
+//! With a router and `ros2 run demo_nodes_cpp talker` running:
+//!
+//! ```text
+//! cargo run --example hz_probe --features ros2 -- string /chatter     # receives
+//! ```
+//!
+//! With a router and `ros2 topic pub -r 2 /probe_image sensor_msgs/msg/Image '{...}'`:
+//!
+//! ```text
+//! cargo run --example hz_probe --features ros2 -- image /probe_image  # times out
+//! ```
+//!
+//! The difference between the two is the `uint8[] data` field. Everything published *from* this
+//! library is received by ROS 2 in both cases.
+use hiroz::Builder;
+use std::time::Duration;
+
+fn main() -> hiroz::Result<()> {
+    if std::env::var("RUST_LOG").is_ok() {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .try_init();
+    }
+    let kind = std::env::args().nth(1).unwrap_or_else(|| "string".into());
+    let topic = std::env::args().nth(2).unwrap_or_else(|| "/chatter".into());
+    let ctx = hiroz::context::ZContextBuilder::default()
+        .connect_to_local_zenohd()
+        .with_mode("client")
+        .build()?;
+    let node = ctx.create_node("hz_probe").build()?;
+    match kind.as_str() {
+        "image" => {
+            let sub = node
+                .create_sub::<hiroz_msgs::sensor_msgs::Image>(&topic)
+                .build()?;
+            for _ in 0..4 {
+                match sub.recv_timeout(Duration::from_secs(8)) {
+                    Ok(m) => println!("got image {}x{} {} bytes", m.width, m.height, m.step),
+                    Err(e) => println!("timeout/err: {e}"),
+                }
+            }
+        }
+        _ => {
+            let sub = node
+                .create_sub::<hiroz_msgs::example_interfaces::String>(&topic)
+                .build()?;
+            for _ in 0..4 {
+                match sub.recv_timeout(Duration::from_secs(8)) {
+                    Ok(m) => println!("got: {}", m.data),
+                    Err(e) => println!("timeout/err: {e}"),
+                }
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/eventcv-core/examples/ros2_node.rs
+++ b/crates/eventcv-core/examples/ros2_node.rs
@@ -1,0 +1,293 @@
+//! The ROS 2 nodes, as a runnable program: `cargo run --example ros2_node --features ros2 -- <cmd>`.
+//!
+//! Nothing here links a ROS 2 library. It talks to a `rmw_zenoh_cpp` deployment over Zenoh, which
+//! is what makes the whole integration a cargo feature rather than a second distribution.
+
+use std::time::{Duration, Instant};
+
+use eventcv_core::io::EvtVersion;
+use eventcv_core::representation::{Representation, VoxelGrid};
+use eventcv_core::ros2::{record_topic, replay_file, Ros2Context};
+
+fn arg(name: &str, default: &str) -> String {
+    let mut args = std::env::args().skip(1);
+    while let Some(a) = args.next() {
+        if a == name {
+            return args.next().unwrap_or_else(|| default.to_owned());
+        }
+    }
+    default.to_owned()
+}
+
+fn flag(name: &str) -> bool {
+    std::env::args().any(|a| a == name)
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // hiroz and zenoh both log through `tracing`; without a subscriber installed the logs go
+    // nowhere, which is unhelpful the first time a topic does not match.
+    if std::env::var("RUST_LOG").is_ok() {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .try_init();
+    }
+    let command = std::env::args().nth(1).unwrap_or_else(|| "help".to_owned());
+    let topic = arg("--topic", "/event_camera/events");
+    let endpoint = arg("--router", "");
+    let mode = arg("--mode", "");
+    let context = Ros2Context::with_endpoint_and_mode(
+        (!endpoint.is_empty()).then_some(endpoint.as_str()),
+        (!mode.is_empty()).then_some(mode.as_str()),
+    )?;
+
+    match command.as_str() {
+        // Replays a recording onto a topic. The publisher a real driver would be.
+        "publish" => {
+            let path = arg("--file", "/tmp/data/evt3.raw");
+            let window: f64 = arg("--window-ms", "33").parse()?;
+            let mut publisher = context.event_publisher("eventcv_publisher", &topic)?;
+            if arg("--encoding", "evt3") == "evt2" {
+                publisher = publisher.with_encoding(EvtVersion::Evt2);
+            }
+            // Give discovery a moment, or the first packets go out before anyone is listening.
+            std::thread::sleep(Duration::from_millis(
+                arg("--settle-ms", "1500").parse::<u64>()?,
+            ));
+            let loops: u32 = arg("--loops", "1").parse()?;
+            let started = Instant::now();
+            let (mut packets, mut events, mut empty) = (0u64, 0usize, 0u64);
+            for _ in 0..loops.max(1) {
+                let report = replay_file(&mut publisher, &path, window, flag("--wall-clock"))?;
+                packets += report.packets;
+                events += report.events;
+                empty += report.empty_windows;
+            }
+            println!(
+                "published {packets} packets, {events} events, {empty} empty windows in {:.2}s",
+                started.elapsed().as_secs_f64()
+            );
+        }
+
+        // Records a topic back to a file, in any format the library writes.
+        "record" => {
+            let out = arg("--out", "/tmp/recorded.raw");
+            let idle: u64 = arg("--idle-ms", "5000").parse()?;
+            let mut subscriber = context.event_subscriber("eventcv_recorder", &topic)?;
+            let report = record_topic(
+                &mut subscriber,
+                &out,
+                Duration::from_millis(idle),
+                arg("--max", "0").parse::<u64>().ok().filter(|&n| n > 0),
+            )?;
+            println!(
+                "recorded {} packets, {} events, {} dropped -> {out}",
+                report.packets, report.events, report.dropped
+            );
+        }
+
+        // Subscribes, builds a representation, publishes it as sensor_msgs/Image.
+        "represent" => {
+            let out_topic = arg("--image-topic", "/event_camera/voxel");
+            let bins: usize = arg("--bins", "3").parse()?;
+            let window: f64 = arg("--window-ms", "33").parse()?;
+            let idle: u64 = arg("--idle-ms", "5000").parse()?;
+            let mut subscriber = context.event_subscriber("eventcv_representation", &topic)?;
+            let images = context.image_publisher("eventcv_representation_out", &out_topic)?;
+            let voxel = VoxelGrid::new(bins, window);
+            let mut made = 0u64;
+            while let Some(packet) = subscriber.recv_packet(Duration::from_millis(idle))? {
+                let stream = packet.decode()?;
+                let frame = voxel.generate(&stream)?;
+                images.publish(&frame, packet.time_base_ns())?;
+                made += 1;
+            }
+            println!(
+                "published {made} images on {out_topic} ({} packets in, {} dropped)",
+                subscriber.received(),
+                subscriber.dropped()
+            );
+        }
+
+        // Subscribes, builds the model's input, runs the graph, publishes the output tensor.
+        #[cfg(feature = "onnx")]
+        "infer" => {
+            let model_path = arg("--model", "");
+            let out_topic = arg("--tensor-topic", "/event_camera/inference");
+            let bins: usize = arg("--bins", "5").parse()?;
+            let window: f64 = arg("--window-ms", "33").parse()?;
+            let idle: u64 = arg("--idle-ms", "5000").parse()?;
+            let model = eventcv_core::model::Model::load(&model_path)?;
+            let subscriber = context.event_subscriber("eventcv_inference", &topic)?;
+            let tensors = context.tensor_publisher("eventcv_inference_out", &out_topic)?;
+            let mut node = eventcv_core::ros2::InferenceNode::with_voxel(
+                subscriber, model, tensors, bins, window,
+            );
+            let (inputs, outputs) = node.ports();
+            println!(
+                "graph: {:?} -> {:?}",
+                inputs.iter().map(|p| &p.shape).collect::<Vec<_>>(),
+                outputs.iter().map(|p| &p.shape).collect::<Vec<_>>()
+            );
+            let n = node.run(Duration::from_millis(idle), None)?;
+            println!("ran {n} inferences, published on {out_topic}");
+        }
+
+        // One process, one context: a publisher and a subscriber that should see each other.
+        // The first thing to check when nothing arrives — it separates a hiroz problem from a
+        // discovery problem.
+        "loopback" => {
+            let mut subscriber = context.event_subscriber("eventcv_loopback_sub", &topic)?;
+            let mut publisher = context.event_publisher("eventcv_loopback_pub", &topic)?;
+            std::thread::sleep(Duration::from_millis(
+                arg("--settle-ms", "3000").parse::<u64>()?,
+            ));
+            let reader = eventcv_core::io::open(
+                arg("--file", "/tmp/data/evt3.raw"),
+                eventcv_core::io::LoadOptions::default(),
+            )?;
+            let (t0, _) = reader.time_span();
+            let slice = reader.slice_time(t0, t0 + 33_000)?;
+            println!("publishing {} events", slice.len());
+            publisher.publish(&slice)?;
+            match subscriber.recv(Duration::from_secs(10))? {
+                Some(back) => println!(
+                    "received {} events, first t {} (sent {})",
+                    back.len(),
+                    back.ts().first().copied().unwrap_or(-1),
+                    slice.ts().first().copied().unwrap_or(-1)
+                ),
+                None => println!("received nothing in 10s"),
+            }
+        }
+
+        // Publishes preloaded windows as fast as the topic will take them, so the number is the
+        // cost of encode + serialize + put, not of reading the file.
+        "bench-pub" => {
+            let path = arg("--file", "/tmp/data/evt3.raw");
+            let window: f64 = arg("--window-ms", "33").parse()?;
+            let reader = eventcv_core::io::open(&path, eventcv_core::io::LoadOptions::default())?;
+            let (t0, t1) = reader.time_span();
+            let step = (window * 1000.0).round() as i64;
+            let mut slices = Vec::new();
+            let mut t = t0;
+            while t <= t1 {
+                let slice = reader.slice_time(t, t + step)?;
+                if !slice.is_empty() {
+                    slices.push(slice);
+                }
+                t += step;
+            }
+            let events: usize = slices.iter().map(|s| s.len()).sum();
+            let mut publisher = context.event_publisher("eventcv_bench_pub", &topic)?;
+            // Pacing, so a run can be made lossless: the default subscriber queue is KeepLast(10),
+            // and an unpaced publisher outruns any consumer by two orders of magnitude.
+            let pace = arg("--pace-us", "0").parse::<u64>()?;
+            std::thread::sleep(Duration::from_millis(
+                arg("--settle-ms", "3000").parse::<u64>()?,
+            ));
+            // After the settle, not before: the offset has to be taken at the moment publishing
+            // starts or every stamp is late by however long discovery took.
+            if flag("--wall-clock") {
+                let now_ns = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)?
+                    .as_nanos() as i64;
+                publisher = publisher.with_clock_offset(now_ns - t0 * 1_000);
+            }
+            // Encode alone, so the split between codec and transport is visible.
+            let encode_start = Instant::now();
+            let mut bytes = 0usize;
+            for (i, slice) in slices.iter().enumerate() {
+                let packet =
+                    eventcv_core::ros2::EventPacket::encode(slice, i as u64, EvtVersion::Evt3)?;
+                bytes += packet.events.len();
+            }
+            let encode = encode_start.elapsed().as_secs_f64();
+            let start = Instant::now();
+            for slice in &slices {
+                publisher.publish(slice)?;
+                if pace > 0 {
+                    std::thread::sleep(Duration::from_micros(pace));
+                }
+            }
+            let total = start.elapsed().as_secs_f64();
+            println!(
+                "packets {} events {} payload {:.2} MB\n\
+                 encode {:.3}s = {:.2} Mev/s\n\
+                 encode+publish {:.3}s = {:.2} Mev/s, {:.0} packets/s, {:.1} MB/s",
+                slices.len(),
+                events,
+                bytes as f64 / 1e6,
+                encode,
+                events as f64 / encode / 1e6,
+                total,
+                events as f64 / total / 1e6,
+                slices.len() as f64 / total,
+                bytes as f64 / total / 1e6,
+            );
+        }
+
+        // Receives packets and reports decode throughput and the wire latency the header implies.
+        "bench-sub" => {
+            let idle: u64 = arg("--idle-ms", "15000").parse()?;
+            let mut subscriber = context.event_subscriber("eventcv_bench_sub", &topic)?;
+            let mut events = 0usize;
+            let mut bytes = 0usize;
+            let mut decode = Duration::ZERO;
+            let mut latencies = Vec::new();
+            let mut first: Option<Instant> = None;
+            let mut last = Instant::now();
+            while let Some(packet) = subscriber.recv_packet(Duration::from_millis(idle))? {
+                let arrived = Instant::now();
+                first.get_or_insert(arrived);
+                let sent_ns = packet.time_base_ns();
+                let now_ns = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)?
+                    .as_nanos() as u64;
+                if sent_ns > 0 && now_ns > sent_ns && now_ns - sent_ns < 10_000_000_000 {
+                    latencies.push((now_ns - sent_ns) as f64 / 1e6);
+                }
+                bytes += packet.events.len();
+                let at = Instant::now();
+                let stream = packet.decode()?;
+                decode += at.elapsed();
+                events += stream.len();
+                last = arrived;
+            }
+            let span = first.map_or(0.0, |f| (last - f).as_secs_f64()).max(1e-9);
+            latencies.sort_by(|a, b| a.partial_cmp(b).unwrap());
+            println!(
+                "packets {} events {} payload {:.2} MB\n\
+                 decode {:.3}s = {:.2} Mev/s\n\
+                 wall {:.3}s = {:.2} Mev/s end to end, {:.1} MB/s, {} dropped",
+                subscriber.received(),
+                events,
+                bytes as f64 / 1e6,
+                decode.as_secs_f64(),
+                events as f64 / decode.as_secs_f64() / 1e6,
+                span,
+                events as f64 / span / 1e6,
+                bytes as f64 / span / 1e6,
+                subscriber.dropped(),
+            );
+            if !latencies.is_empty() {
+                println!(
+                    "latency ms: median {:.2}, p95 {:.2}, max {:.2} (n={})",
+                    latencies[latencies.len() / 2],
+                    latencies[latencies.len() * 95 / 100],
+                    latencies[latencies.len() - 1],
+                    latencies.len()
+                );
+            }
+        }
+
+        other => {
+            eprintln!(
+                "usage: ros2_node <publish|record|represent|infer> [--topic T] [--file F] \
+                 [--out F] [--window-ms N] [--bins N] [--idle-ms N] [--wall-clock] [--router E]\n\
+                 unknown command: {other}"
+            );
+            std::process::exit(2);
+        }
+    }
+    Ok(())
+}

--- a/crates/eventcv-core/examples/rt_check.rs
+++ b/crates/eventcv-core/examples/rt_check.rs
@@ -1,0 +1,44 @@
+//! Compares two recordings event for event. Used to check the ROS 2 round-trip.
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = std::env::args().skip(1);
+    let a = eventcv_core::io::load(args.next().unwrap(), Default::default())?;
+    let b = eventcv_core::io::load(args.next().unwrap(), Default::default())?;
+    println!("a: {} events, b: {} events", a.len(), b.len());
+    println!("sensor: {:?} vs {:?}", a.sensor_size(), b.sensor_size());
+    if a.len() != b.len() {
+        println!("MISMATCH: lengths differ");
+        return Ok(());
+    }
+    let mut bad = 0usize;
+    for i in 0..a.len() {
+        if a.xs()[i] != b.xs()[i]
+            || a.ys()[i] != b.ys()[i]
+            || a.ts()[i] != b.ts()[i]
+            || a.ps()[i] != b.ps()[i]
+        {
+            if bad < 5 {
+                println!(
+                    "  [{i}] ({},{},{},{}) vs ({},{},{},{})",
+                    a.xs()[i],
+                    a.ys()[i],
+                    a.ts()[i],
+                    a.ps()[i],
+                    b.xs()[i],
+                    b.ys()[i],
+                    b.ts()[i],
+                    b.ps()[i]
+                );
+            }
+            bad += 1;
+        }
+    }
+    println!(
+        "{}",
+        if bad == 0 {
+            "IDENTICAL".to_owned()
+        } else {
+            format!("{bad} events differ")
+        }
+    );
+    Ok(())
+}

--- a/crates/eventcv-core/examples/slice_bench.rs
+++ b/crates/eventcv-core/examples/slice_bench.rs
@@ -1,0 +1,22 @@
+//! Per-slice cost on the lazy path: open once, then pull fixed windows.
+use std::time::Instant;
+use eventcv_core::io::{open_raw_slice, LoadOptions, SliceSource};
+fn main() {
+    let path = std::env::args().nth(1).unwrap();
+    let o = LoadOptions::default();
+    let t0 = Instant::now();
+    let src = open_raw_slice(&path, &o).unwrap();
+    println!("open (index pass)      {:8.2} ms  ({} events)", t0.elapsed().as_secs_f64()*1e3, src.n_events());
+    let (lo, hi) = src.time_span();
+    let dt = 33_000i64;
+    let mut total = 0usize;
+    let t1 = Instant::now();
+    let mut n = 0;
+    let mut t = lo;
+    while t + dt <= hi { total += src.slice_time(t, t + dt).unwrap().len(); t += dt; n += 1; }
+    let ms = t1.elapsed().as_secs_f64()*1e3;
+    println!("{n} slices of 33 ms     {ms:8.2} ms total, {:.3} ms/slice ({total} events)", ms / n as f64);
+    let t2 = Instant::now();
+    let whole = src.slice_index(0, src.n_events()).unwrap();
+    println!("slice_index(0, all)    {:8.2} ms  ({} events)", t2.elapsed().as_secs_f64()*1e3, whole.len());
+}

--- a/crates/eventcv-core/src/device.rs
+++ b/crates/eventcv-core/src/device.rs
@@ -388,6 +388,25 @@ impl Windower {
         self.advance_to(t_now);
     }
 
+    /// Throws away the window currently filling, and any aux riding with it.
+    ///
+    /// For [`Capture::skim_next`], which discards a span of events on purpose: whatever had already
+    /// accumulated into the current window covers part of that span, so delivering it would mean
+    /// handing back a window with a hole in it. A window that is missing is honest; a window that
+    /// silently under-counts is not, and nothing downstream could tell.
+    fn discard_partial(&mut self) {
+        if !self.builder.is_empty() {
+            self.builder = EventStreamBuilder::with_capacity(
+                self.width,
+                self.height,
+                TIMESTAMP_SCALE_MS,
+                self.builder.len(),
+            );
+        }
+        self.frames.clear();
+        self.imu.clear();
+    }
+
     /// Seals the current window into `pending` and starts a fresh one.
     ///
     /// The replacement is sized from the window just sealed: consecutive windows hold similar event
@@ -441,14 +460,12 @@ impl AdaptiveBias {
         // The defaults the request lands on are the sensor's own: rates scale with pixel count, and
         // the registers are a 2041-step current ladder on one sensor and plain bytes on the other.
         let (base, start) = match device.current_configuration() {
-            nd::Configuration::InivationDavis346(configuration) => (
-                BiasConfig::davis346(),
-                davis346_biases(&configuration)?,
-            ),
-            nd::Configuration::PropheseeEvk4(configuration) => (
-                BiasConfig::prophesee_evk4(),
-                evk4_biases(&configuration),
-            ),
+            nd::Configuration::InivationDavis346(configuration) => {
+                (BiasConfig::davis346(), davis346_biases(&configuration)?)
+            }
+            nd::Configuration::PropheseeEvk4(configuration) => {
+                (BiasConfig::prophesee_evk4(), evk4_biases(&configuration))
+            }
             _ => {
                 return Err(format!(
                     "adaptive_bias is not supported on the {} — it is implemented for the \
@@ -794,6 +811,52 @@ impl Capture {
         Ok(decoded)
     }
 
+    /// Decodes one queued buffer for its state alone, discarding its events. Returns how many were
+    /// discarded, or `None` when the ring was empty.
+    ///
+    /// EVT3 is a stateful stream — timestamps arrive as `TIME_HIGH`/`TIME_LOW` words and rows as
+    /// `ADDR_Y`, each applying to every event that follows — so a buffer cannot simply be dropped
+    /// without leaving the decoder misaligned for the events after it. Skimming decodes the words
+    /// and keeps that state exact, and skips only the windowing and column building, which is the
+    /// half that allocates.
+    ///
+    /// For `stream(latest=True)`, where the windows behind the freshest one are going to be thrown
+    /// away regardless: building them first is work spent on a result nobody reads, and the time it
+    /// costs is time the ring spends filling.
+    pub fn skim_next(&mut self, timeout: Duration) -> Result<Option<usize>, String> {
+        self.flag.load_error().map_err(|error| error.to_string())?;
+        let mut events = 0;
+        // Scoped like `decode_next`'s: the view borrows the device and frees its ring slot when
+        // dropped, so it has to go before the bias controller is handed the device below.
+        {
+            let Some(view) = self.device.next_with_timeout(&timeout) else {
+                return Ok(None);
+            };
+            if view.first_after_overflow {
+                self.windower.mark_overflow();
+            }
+            convert_buffer(
+                &mut self.adapter,
+                view.slice,
+                self.mask.as_deref(),
+                (self.width, self.height),
+                |_x, _y, _t, _polarity| events += 1,
+                &mut self.aux,
+            );
+        }
+        // Frames and IMU decoded over a span whose events are being discarded belong to that span,
+        // so they go with it rather than riding out on the next window as if they were part of it.
+        let _ = self.aux.take();
+        self.windower.discard_partial();
+        let current_t = self.adapter.current_t() as i64;
+        self.windower.seal_until(current_t);
+        // The events were real and were counted exactly, so the bias controller is told the truth:
+        // marking this as an undercount would have it read a deliberately discarded span as a quiet
+        // scene and open the sensor up, which is the opposite of what an overloaded pipeline needs.
+        self.tick_bias(events, false);
+        Ok(Some(events as usize))
+    }
+
     /// Takes the next window that has **already** completed, without touching the device. Returns
     /// `None` once the queue sealed by [`poll`] / [`catch_up`] is empty.
     pub fn take_pending(&mut self) -> Option<CaptureWindow> {
@@ -973,8 +1036,8 @@ fn plan_limits(device: &nd::devices::ListedDevice, limits: Limits) -> Result<Lim
 /// per period still admits one, since the register cannot express "none".
 fn rate_limiter(max_event_rate: Option<u64>) -> Option<(u16, u32)> {
     let rate = max_event_rate?;
-    let per_period = (rate * RATE_LIMIT_PERIOD_US as u64 / 1_000_000)
-        .clamp(1, RATE_LIMIT_MAX_PER_PERIOD) as u32;
+    let per_period =
+        (rate * RATE_LIMIT_PERIOD_US as u64 / 1_000_000).clamp(1, RATE_LIMIT_MAX_PER_PERIOD) as u32;
     Some((RATE_LIMIT_PERIOD_US, per_period))
 }
 
@@ -1223,7 +1286,7 @@ fn device_dimensions(device: &nd::Device) -> (usize, usize) {
 
 #[cfg(test)]
 mod tests {
-    use super::{rate_limiter, region_masks, Window, Windower};
+    use super::{rate_limiter, region_masks, ImuSample, Window, Windower};
 
     #[test]
     fn rate_limiter_converts_events_per_second_to_a_period_budget() {
@@ -1291,6 +1354,48 @@ mod tests {
         assert!(region_masks::<20, 12>((0, 0, 0, 100), 1280, 720).is_err());
         // The same rectangle is off a 640x480 sensor, so the check is per sensor, not per model.
         assert!(region_masks::<10, 8>((0, 0, 1280, 720), 640, 480).is_err());
+    }
+
+    #[test]
+    fn a_discarded_partial_window_is_never_delivered() {
+        // What `skim_next` relies on: events accumulated into the window that is currently
+        // filling belong to the span being thrown away, so that window must go with them rather
+        // than arrive short. A missing window is honest; one that quietly under-counts is not.
+        let mut windower = Windower::new(10, 10, Window::Duration(1.0));
+        windower.push(1, 1, 0, true); // anchors the grid: boundary -> 1000
+        windower.push(2, 2, 100, true);
+        assert_eq!(windower.pending.len(), 0, "still filling");
+
+        windower.discard_partial();
+        // The grid keeps moving, but nothing half-filled comes out of it.
+        windower.seal_until(5_000);
+        assert_eq!(windower.pending.len(), 0, "no short window was delivered");
+
+        // And the next real event starts a clean window on the same grid.
+        windower.push(3, 3, 5_100, true);
+        windower.seal_until(7_000);
+        assert_eq!(windower.pending.len(), 1);
+        assert_eq!(windower.pending[0].stream.len(), 1);
+    }
+
+    #[test]
+    fn discarding_a_partial_window_drops_its_aux_too() {
+        // Frames and IMU decoded over the discarded span belong to it. Riding out on the next
+        // window would put them beside events they did not happen with.
+        let mut windower = Windower::new(10, 10, Window::Duration(1.0));
+        windower.push(1, 1, 0, true);
+        windower.push_aux(
+            vec![],
+            vec![ImuSample {
+                t_us: 100,
+                angular_velocity: [0.0; 3],
+                linear_acceleration: [0.0; 3],
+            }],
+        );
+        assert_eq!(windower.imu.len(), 1);
+
+        windower.discard_partial();
+        assert!(windower.imu.is_empty(), "aux went with the span it covered");
     }
 
     #[test]

--- a/crates/eventcv-core/src/io.rs
+++ b/crates/eventcv-core/src/io.rs
@@ -29,7 +29,7 @@ pub use h5::{
 };
 pub use npz::{read_npz, read_npz_frame, write_npz_frame, write_npz_stream, NpzEventSink};
 pub use prophesee::{read_dat, DatEventSink};
-pub use prophesee_raw::{open_raw_slice, read_raw, EvtVersion, RawEventSink};
+pub use prophesee_raw::{decode_words, open_raw_slice, read_raw, EvtVersion, RawEventSink};
 pub use text::{
     load_rows, open_text_slice, read_text, write_text_stream, ColumnOrder, RawRow, TextEventSink,
     TextOptions, TextReader, TimeUnit,

--- a/crates/eventcv-core/src/io/aedat4.rs
+++ b/crates/eventcv-core/src/io/aedat4.rs
@@ -21,6 +21,8 @@ use std::fs::File;
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
+use rayon::prelude::*;
+
 use super::{ImuSample, IoError, LoadOptions, SliceSource};
 use crate::representation::{EventFrame, EventFrameData};
 use crate::{EventStream, EventStreamBuilder};
@@ -243,22 +245,34 @@ impl Compression {
         }
     }
 
-    fn decode(self, body: Vec<u8>) -> Result<Vec<u8>, IoError> {
+    fn decode(self, body: &[u8]) -> Result<Vec<u8>, IoError> {
+        let mut out = Vec::new();
+        self.decode_into(body, &mut out)?;
+        Ok(out)
+    }
+
+    /// Decompresses into a caller-owned buffer. A recording is a few hundred packets of similar
+    /// size, so one buffer that keeps its capacity replaces a few hundred Vecs that each grow to
+    /// the packet size by doubling.
+    fn decode_into(self, body: &[u8], out: &mut Vec<u8>) -> Result<(), IoError> {
+        out.clear();
         match self {
-            Self::None => Ok(body),
+            Self::None => out.extend_from_slice(body),
             // DV writes LZ4 in its frame format, not raw blocks.
             Self::Lz4 => {
-                let mut out = Vec::new();
-                lz4::Decoder::new(body.as_slice())
-                    .and_then(|mut decoder| decoder.read_to_end(&mut out))
+                lz4::Decoder::new(body)
+                    .and_then(|mut decoder| decoder.read_to_end(out))
                     .map_err(|error| {
                         IoError::Format(format!("AEDAT4 LZ4 packet is corrupt: {error}"))
                     })?;
-                Ok(out)
             }
-            Self::Zstd => zstd::stream::decode_all(body.as_slice())
-                .map_err(|error| IoError::Format(format!("AEDAT4 zstd packet is corrupt: {error}"))),
+            Self::Zstd => {
+                zstd::stream::copy_decode(body, &mut *out).map_err(|error| {
+                    IoError::Format(format!("AEDAT4 zstd packet is corrupt: {error}"))
+                })?;
+            }
         }
+        Ok(())
     }
 }
 
@@ -391,10 +405,68 @@ fn read_body(
     size: usize,
 ) -> Result<Vec<u8>, IoError> {
     let mut file = File::open(path)?;
+    let mut buffers = Buffers::default();
+    read_body_with(&mut file, compression, offset, size, &mut buffers)?;
+    Ok(std::mem::take(&mut buffers.plain))
+}
+
+/// The same, on a handle the caller already holds and a buffer it reuses. Reading a recording's
+/// events touches one packet after another, so opening the file per packet is one `open` and one
+/// `close` syscall per few thousand events, and `vec![0u8; size]` zeroes a buffer that is about to
+/// be overwritten in full.
+fn read_body_with(
+    file: &mut File,
+    compression: Compression,
+    offset: u64,
+    size: usize,
+    buffers: &mut Buffers,
+) -> Result<(), IoError> {
     file.seek(SeekFrom::Start(offset))?;
-    let mut body = vec![0u8; size];
-    file.read_exact(&mut body)?;
-    compression.decode(body)
+    buffers.compressed.clear();
+    buffers.compressed.resize(size, 0);
+    file.read_exact(&mut buffers.compressed)?;
+    let (compressed, plain) = (&buffers.compressed, &mut buffers.plain);
+    compression.decode_into(compressed, plain)
+}
+
+/// The two buffers a packet-by-packet read reuses: the compressed bytes off disk, and the
+/// decompressed body they expand into.
+#[derive(Default)]
+struct Buffers {
+    compressed: Vec<u8>,
+    plain: Vec<u8>,
+}
+
+/// Above this many packets, `slice_index` decodes them in parallel. One window of a recording is
+/// a packet or two, and paying for a thread-pool hand-off there would slow down the case a
+/// real-time loop actually runs.
+const PARALLEL_PACKET_THRESHOLD: usize = 8;
+
+/// One packet's decoded events, before they are appended to the stream in packet order.
+struct Columns {
+    xs: Vec<u16>,
+    ys: Vec<u16>,
+    ts: Vec<i64>,
+    ps: Vec<bool>,
+}
+
+impl Columns {
+    fn with_capacity(capacity: usize) -> Self {
+        Self {
+            xs: Vec::with_capacity(capacity),
+            ys: Vec::with_capacity(capacity),
+            ts: Vec::with_capacity(capacity),
+            ps: Vec::with_capacity(capacity),
+        }
+    }
+
+    #[inline]
+    fn push(&mut self, x: u16, y: u16, t: i64, p: bool) {
+        self.xs.push(x);
+        self.ys.push(y);
+        self.ts.push(t);
+        self.ps.push(p);
+    }
 }
 
 /// Lazy, indexed source for an AEDAT 4 recording.
@@ -485,14 +557,38 @@ impl Aedat4SliceSource {
         read_body(&self.path, self.compression, packet.offset, packet.size)
     }
 
+    /// `body`, reusing a handle and a scratch buffer across packets.
+    fn body_with(
+        &self,
+        file: &mut File,
+        buffers: &mut Buffers,
+        packet: &Packet,
+    ) -> Result<(), IoError> {
+        read_body_with(file, self.compression, packet.offset, packet.size, buffers)
+    }
+
     /// Decodes every event in `packet`, handing each to `visit` with its index in the stream.
     fn each_event(
         &self,
         packet: &Packet,
+        visit: impl FnMut(usize, u16, u16, i64, bool),
+    ) -> Result<(), IoError> {
+        let mut file = File::open(&self.path)?;
+        let mut buffers = Buffers::default();
+        self.each_event_with(&mut file, &mut buffers, packet, visit)
+    }
+
+    /// `each_event`, on a handle and scratch buffer the caller reuses across packets.
+    fn each_event_with(
+        &self,
+        file: &mut File,
+        buffers: &mut Buffers,
+        packet: &Packet,
         mut visit: impl FnMut(usize, u16, u16, i64, bool),
     ) -> Result<(), IoError> {
-        let body = self.body(packet)?;
-        let table = Table::size_prefixed_root(&body)
+        self.body_with(file, buffers, packet)?;
+        let body = &buffers.plain;
+        let table = Table::size_prefixed_root(body)
             .ok_or_else(|| IoError::Format("AEDAT4 event packet is not readable".to_owned()))?;
         let Some((bytes, elements)) = table.vector(slot::ELEMENTS, EVENT_STRIDE) else {
             return Ok(());
@@ -531,24 +627,79 @@ impl SliceSource for Aedat4SliceSource {
     fn slice_index(&self, i0: usize, i1: usize) -> Result<EventStream, IoError> {
         let i0 = i0.min(self.n_events);
         let i1 = i1.clamp(i0, self.n_events);
-        let mut builder = EventStreamBuilder::new(self.width, self.height, TIMESTAMP_SCALE_MS);
-        for packet in &self.events {
-            if packet.first >= i1 || packet.first + packet.elements <= i0 {
-                continue;
+        let selected: Vec<&Packet> = self
+            .events
+            .iter()
+            .filter(|packet| packet.first < i1 && packet.first + packet.elements > i0)
+            .collect();
+
+        // AEDAT 4 packets are self-contained -- a compressed body, a flatbuffer, and absolute
+        // timestamps -- so decoding them does not have to be sequential the way a stateful EVT3
+        // stream does. Above a handful of packets the decompression, which is most of the cost,
+        // goes wide. Below it the thread-pool hand-off costs more than it saves, which is the case
+        // that matters most: a robot pulling one window.
+        if selected.len() < PARALLEL_PACKET_THRESHOLD {
+            let mut builder = EventStreamBuilder::with_capacity(
+                self.width,
+                self.height,
+                TIMESTAMP_SCALE_MS,
+                i1 - i0,
+            );
+            let mut file = File::open(&self.path)?;
+            let mut buffers = Buffers::default();
+            for packet in selected {
+                self.each_event_with(&mut file, &mut buffers, packet, |index, x, y, t, p| {
+                    if index >= i0 && index < i1 {
+                        builder.push(x, y, t, p);
+                    }
+                })?;
             }
-            self.each_event(packet, |index, x, y, t, p| {
-                if index >= i0 && index < i1 {
-                    builder.push(x, y, t, p);
-                }
-            })?;
+            return Ok(builder.build());
+        }
+
+        let columns: Result<Vec<Columns>, IoError> = selected
+            .par_iter()
+            .map_init(
+                || (File::open(&self.path), Buffers::default()),
+                |(file, buffers), packet| {
+                    let file = file.as_mut().map_err(|error| {
+                        IoError::Io(std::io::Error::new(error.kind(), error.to_string()))
+                    })?;
+                    let mut out = Columns::with_capacity(packet.elements);
+                    self.each_event_with(file, buffers, packet, |index, x, y, t, p| {
+                        if index >= i0
+                            && index < i1
+                            && usize::from(x) < self.width
+                            && usize::from(y) < self.height
+                        {
+                            out.push(x, y, t, p);
+                        }
+                    })?;
+                    Ok(out)
+                },
+            )
+            .collect();
+
+        let columns = columns?;
+        let mut builder = EventStreamBuilder::with_capacity(
+            self.width,
+            self.height,
+            TIMESTAMP_SCALE_MS,
+            columns.iter().map(|c| c.ts.len()).sum(),
+        );
+        // Packets are in time order, so appending their columns in order preserves it.
+        for c in &columns {
+            builder.extend_from_columns(&c.xs, &c.ys, &c.ts, &c.ps);
         }
         Ok(builder.build())
     }
 
     fn slice_time(&self, t0: i64, t1: i64) -> Result<EventStream, IoError> {
         let mut builder = EventStreamBuilder::new(self.width, self.height, TIMESTAMP_SCALE_MS);
+        let mut file = File::open(&self.path)?;
+        let mut buffers = Buffers::default();
         for packet in overlapping(&self.events, t0, t1) {
-            self.each_event(packet, |_, x, y, t, p| {
+            self.each_event_with(&mut file, &mut buffers, packet, |_, x, y, t, p| {
                 if t >= t0 && t < t1 {
                     builder.push(x, y, t, p);
                 }

--- a/crates/eventcv-core/src/io/aedat4.rs
+++ b/crates/eventcv-core/src/io/aedat4.rs
@@ -217,7 +217,7 @@ impl Compression {
     }
 
     /// Compresses one packet body for writing. LZ4 goes out in the *frame* format DV expects,
-    /// which is what [`decode`](Self::decode) reads back.
+    /// which is what [`decode_into`](Self::decode_into) reads back.
     fn encode(self, body: &[u8]) -> Result<Vec<u8>, IoError> {
         match self {
             Self::None => Ok(body.to_vec()),
@@ -243,12 +243,6 @@ impl Compression {
                 "unknown AEDAT4 compression type {other}"
             ))),
         }
-    }
-
-    fn decode(self, body: &[u8]) -> Result<Vec<u8>, IoError> {
-        let mut out = Vec::new();
-        self.decode_into(body, &mut out)?;
-        Ok(out)
     }
 
     /// Decompresses into a caller-owned buffer. A recording is a few hundred packets of similar
@@ -567,18 +561,8 @@ impl Aedat4SliceSource {
         read_body_with(file, self.compression, packet.offset, packet.size, buffers)
     }
 
-    /// Decodes every event in `packet`, handing each to `visit` with its index in the stream.
-    fn each_event(
-        &self,
-        packet: &Packet,
-        visit: impl FnMut(usize, u16, u16, i64, bool),
-    ) -> Result<(), IoError> {
-        let mut file = File::open(&self.path)?;
-        let mut buffers = Buffers::default();
-        self.each_event_with(&mut file, &mut buffers, packet, visit)
-    }
-
-    /// `each_event`, on a handle and scratch buffer the caller reuses across packets.
+    /// Decodes every event in `packet`, handing each to `visit` with its index in the stream,
+    /// on a file handle and scratch buffer the caller reuses across packets.
     fn each_event_with(
         &self,
         file: &mut File,

--- a/crates/eventcv-core/src/io/prophesee_raw.rs
+++ b/crates/eventcv-core/src/io/prophesee_raw.rs
@@ -25,7 +25,24 @@ const TIMESTAMP_SCALE_MS: f64 = 0.001;
 const TIME_LOOP: i64 = 1 << 24;
 const MAX_TIMESTAMP_BASE: i64 = ((1 << 12) - 1) << 12;
 const LOOP_THRESHOLD: i64 = 10 << 12;
-const CHECKPOINT_BYTES: u64 = 1 << 20;
+/// Bounds on how far apart saved decoder states sit. A slice replays from the nearest one, so the
+/// interval is what a short window costs: at 1 MiB a 33 ms window of a 0.1 Mev/s recording spent
+/// ten times longer replaying words it then threw away than decoding the ones it wanted.
+const CHECKPOINT_MIN_BYTES: u64 = 1 << 16;
+const CHECKPOINT_MAX_BYTES: u64 = 1 << 22;
+/// Roughly how many checkpoints to keep, whatever the file size: enough that a slice replays
+/// little, few enough that a 30 GB recording's index stays in the tens of megabytes.
+const CHECKPOINT_TARGET: u64 = 200_000;
+
+/// The interval for a file of `bytes`, clamped to the bounds above.
+fn checkpoint_interval(bytes: u64) -> u64 {
+    (bytes / CHECKPOINT_TARGET).clamp(CHECKPOINT_MIN_BYTES, CHECKPOINT_MAX_BYTES)
+}
+/// Read granularity for the eager reader, which never looks back.
+const EAGER_CHUNK_BYTES: u64 = 1 << 20;
+/// Read granularity for the slice methods. Large enough that the per-read cost disappears against
+/// the decode, small enough that a one-window slice does not pull in a megabyte to throw away.
+const SLICE_CHUNK_BYTES: u64 = 1 << 16;
 
 /// EVT2 splits a timestamp into a 28-bit high half (its own word) and a 6-bit low half carried by
 /// each CD event, so the high half is stored pre-shifted and the wrap period is `1 << 34` µs — about
@@ -362,13 +379,13 @@ impl RawSliceSource {
         // which matters because `EventStreamBuilder::push` drops silently.
         let mut extent = (0usize, 0usize);
         let mut byte_offset = header.data_offset;
-        let mut chunk = Vec::with_capacity(CHECKPOINT_BYTES as usize);
+        let interval =
+            checkpoint_interval(reader.get_ref().metadata().map(|m| m.len()).unwrap_or(0));
+        let mut chunk = Vec::with_capacity(interval as usize);
 
         loop {
             chunk.clear();
-            (&mut reader)
-                .take(CHECKPOINT_BYTES)
-                .read_to_end(&mut chunk)?;
+            (&mut reader).take(interval).read_to_end(&mut chunk)?;
             if chunk.is_empty() {
                 break;
             }
@@ -475,23 +492,36 @@ impl SliceSource for RawSliceSource {
         let mut reader = self.reader_at(checkpoint)?;
         let mut codec = checkpoint.codec;
         let mut index = checkpoint.event_index;
-        let mut builder = EventStreamBuilder::new(self.width, self.height, TIMESTAMP_SCALE_MS);
-        let mut bytes = [0u8; 4];
+        let (width, height) = (self.width, self.height);
+        // The event count is known exactly, so the four column vectors are sized once instead of
+        // doubling their way to a million events.
+        let mut builder =
+            EventStreamBuilder::with_capacity(width, height, TIMESTAMP_SCALE_MS, i1 - i0);
         let word_size = codec.word_size();
-        while index < i1 {
-            match reader.read_exact(&mut bytes[..word_size]) {
-                Ok(()) => {}
-                Err(error) if error.kind() == std::io::ErrorKind::UnexpectedEof => break,
-                Err(error) => return Err(IoError::Io(error)),
+        // Decode out of a chunk buffer, the way the index pass does. Reading one two-byte word at
+        // a time through `read_exact` costs a call, a bounds test and a buffer-position update per
+        // word, which dominates the decode itself.
+        let mut chunk = Vec::with_capacity(SLICE_CHUNK_BYTES as usize);
+        'chunks: while index < i1 {
+            chunk.clear();
+            (&mut reader).take(SLICE_CHUNK_BYTES).read_to_end(&mut chunk)?;
+            if chunk.len() < word_size {
+                break;
             }
-            codec.decode(&bytes[..word_size], |event| {
-                if usize::from(event.x) < self.width && usize::from(event.y) < self.height {
-                    if index >= i0 && index < i1 {
-                        builder.push(event.x, event.y, event.t, event.p);
+            for bytes in chunk.chunks_exact(word_size) {
+                codec.decode(bytes, |event| {
+                    if usize::from(event.x) < width && usize::from(event.y) < height {
+                        if index >= i0 && index < i1 {
+                            // Bounds were just tested; `push` would test them again.
+                            builder.push_in_bounds(event.x, event.y, event.t, event.p);
+                        }
+                        index += 1;
                     }
-                    index += 1;
+                });
+                if index >= i1 {
+                    break 'chunks;
                 }
-            });
+            }
         }
         Ok(builder.build())
     }
@@ -500,26 +530,29 @@ impl SliceSource for RawSliceSource {
         let checkpoint = self.checkpoint_for_time(t0);
         let mut reader = self.reader_at(checkpoint)?;
         let mut codec = checkpoint.codec;
-        let mut builder = EventStreamBuilder::new(self.width, self.height, TIMESTAMP_SCALE_MS);
-        let mut bytes = [0u8; 4];
+        let (width, height) = (self.width, self.height);
+        let mut builder = EventStreamBuilder::new(width, height, TIMESTAMP_SCALE_MS);
         let word_size = codec.word_size();
-        loop {
-            match reader.read_exact(&mut bytes[..word_size]) {
-                Ok(()) => {}
-                Err(error) if error.kind() == std::io::ErrorKind::UnexpectedEof => break,
-                Err(error) => return Err(IoError::Io(error)),
-            }
-            codec.decode(&bytes[..word_size], |event| {
-                if event.t >= t0
-                    && event.t < t1
-                    && usize::from(event.x) < self.width
-                    && usize::from(event.y) < self.height
-                {
-                    builder.push(event.x, event.y, event.t, event.p);
-                }
-            });
-            if codec.initialised() && codec.time() >= t1 {
+        let mut chunk = Vec::with_capacity(SLICE_CHUNK_BYTES as usize);
+        'chunks: loop {
+            chunk.clear();
+            (&mut reader).take(SLICE_CHUNK_BYTES).read_to_end(&mut chunk)?;
+            if chunk.len() < word_size {
                 break;
+            }
+            for bytes in chunk.chunks_exact(word_size) {
+                codec.decode(bytes, |event| {
+                    if event.t >= t0
+                        && event.t < t1
+                        && usize::from(event.x) < width
+                        && usize::from(event.y) < height
+                    {
+                        builder.push_in_bounds(event.x, event.y, event.t, event.p);
+                    }
+                });
+                if codec.initialised() && codec.time() >= t1 {
+                    break 'chunks;
+                }
             }
         }
         Ok(builder.build())
@@ -535,10 +568,63 @@ pub fn open_raw_slice(
 }
 
 /// Eagerly reads a Prophesee EVT3 RAW file. Prefer [`open_raw_slice`] for large recordings.
+///
+/// With a declared geometry --- which every recorder that writes a `% geometry` line gives us ---
+/// nothing in the result depends on the checkpoint index, so the file is decoded once, straight
+/// into the stream. Only a header without a geometry needs the index pass first: the sensor size
+/// is then derived from the events, and that cannot be known until they have all been seen.
 pub fn read_raw(path: impl AsRef<Path>, options: &LoadOptions) -> Result<EventStream, IoError> {
-    let source = open_raw_slice(path, options)?;
-    let limit = options.max_events.unwrap_or(source.n_events());
-    source.slice_index(0, limit)
+    let path = path.as_ref();
+    let mut reader = BufReader::new(File::open(path)?);
+    let header = parse_header(&mut reader, options.sensor_size)?;
+    let Some((width, height)) = header.sensor_size else {
+        let source = open_raw_slice(path, options)?;
+        let limit = options.max_events.unwrap_or(source.n_events());
+        return source.slice_index(0, limit);
+    };
+
+    let limit = options.max_events.unwrap_or(usize::MAX);
+    let mut codec = Codec::new(header.encoding);
+    let word_size = codec.word_size();
+    let mut builder = EventStreamBuilder::new(width, height, TIMESTAMP_SCALE_MS);
+    let mut count = 0usize;
+    let total_bytes = reader.get_ref().metadata().map(|m| m.len()).unwrap_or(0);
+    let mut bytes_read = 0u64;
+    let mut reserved = false;
+    let mut chunk = Vec::with_capacity(EAGER_CHUNK_BYTES as usize);
+    'chunks: loop {
+        chunk.clear();
+        (&mut reader).take(EAGER_CHUNK_BYTES).read_to_end(&mut chunk)?;
+        if chunk.len() < word_size {
+            break;
+        }
+        bytes_read += chunk.len() as u64;
+        for bytes in chunk.chunks_exact(word_size) {
+            codec.decode(bytes, |event| {
+                if count < limit
+                    && usize::from(event.x) < width
+                    && usize::from(event.y) < height
+                {
+                    builder.push_in_bounds(event.x, event.y, event.t, event.p);
+                    count += 1;
+                }
+            });
+            if count >= limit {
+                break 'chunks;
+            }
+        }
+        // One reservation, sized from the density the first chunk showed, rather than twenty
+        // doublings of a column that ends up holding millions of events. A vectorised EVT3 stream
+        // emits anywhere from a fraction of an event per word to twelve of them, so the file size
+        // alone gives no useful bound; its own first megabyte does.
+        if !reserved && total_bytes > bytes_read {
+            let projected =
+                (count as u128 * u128::from(total_bytes) / u128::from(bytes_read)) as usize;
+            builder.reserve(projected.saturating_sub(count).min(limit));
+            reserved = true;
+        }
+    }
+    Ok(builder.build())
 }
 
 /// Which of the two `.raw` encodings [`RawEventSink`] writes.
@@ -822,7 +908,7 @@ mod tests {
     #[test]
     fn slices_from_a_sparse_checkpoint() {
         let mut words = vec![word(0x8, 0), word(0x6, 10), word(0x0, 4)];
-        while words.len() < (CHECKPOINT_BYTES as usize / 2) - 1 {
+        while words.len() < (CHECKPOINT_MIN_BYTES as usize / 2) - 1 {
             words.push(word(0x9, 0));
         }
         words.push(word(0x2, 7));

--- a/crates/eventcv-core/src/io/prophesee_raw.rs
+++ b/crates/eventcv-core/src/io/prophesee_raw.rs
@@ -559,6 +559,40 @@ impl SliceSource for RawSliceSource {
     }
 }
 
+/// Decodes encoded words with no file and no header around them.
+///
+/// The read side of [`RawEventSink::to_writer`] with `header = false`: a transport that states
+/// the geometry itself (ROS 2's `event_camera_msgs/msg/EventPacket` carries `width`, `height`
+/// and `encoding` in its own fields) sends the encoded words alone, so there is no `% geometry`
+/// line to parse and no file to seek in.
+pub fn decode_words(
+    bytes: &[u8],
+    version: EvtVersion,
+    width: usize,
+    height: usize,
+) -> Result<EventStream, IoError> {
+    if width == 0 || height == 0 {
+        return Err(IoError::InvalidSensorSize);
+    }
+    let mut codec = Codec::new(match version {
+        EvtVersion::Evt2 => Encoding::Evt2,
+        EvtVersion::Evt3 => Encoding::Evt3,
+    });
+    let word_size = codec.word_size();
+    // At most one event per word for EVT2, and vectorised EVT3 words emit more, so this is a
+    // starting point rather than a bound.
+    let mut builder =
+        EventStreamBuilder::with_capacity(width, height, TIMESTAMP_SCALE_MS, bytes.len() / word_size);
+    for word in bytes.chunks_exact(word_size) {
+        codec.decode(word, |event| {
+            if usize::from(event.x) < width && usize::from(event.y) < height {
+                builder.push_in_bounds(event.x, event.y, event.t, event.p);
+            }
+        });
+    }
+    Ok(builder.build())
+}
+
 /// Opens a Prophesee EVT3 RAW file for bounded-memory random slicing.
 pub fn open_raw_slice(
     path: impl AsRef<Path>,
@@ -649,8 +683,8 @@ pub enum EvtVersion {
 /// coarse half that is emitted only when it changes, so a backwards step would be encoded as a
 /// counter wrap and silently move the event forwards by hours. Out-of-order input is rejected
 /// rather than mis-encoded.
-pub struct RawEventSink {
-    writer: BufWriter<File>,
+pub struct RawEventSink<W: Write = BufWriter<File>> {
+    writer: W,
     version: EvtVersion,
     header_written: bool,
     n_events: usize,
@@ -668,7 +702,7 @@ struct EncoderState {
     y: Option<u16>,
 }
 
-impl RawEventSink {
+impl RawEventSink<BufWriter<File>> {
     pub fn create(path: impl AsRef<Path>, version: EvtVersion) -> Result<Self, IoError> {
         Ok(Self {
             writer: BufWriter::new(File::create(path).map_err(IoError::Io)?),
@@ -678,6 +712,32 @@ impl RawEventSink {
             last_t: None,
             state: EncoderState::default(),
         })
+    }
+
+}
+
+impl<W: Write> RawEventSink<W> {
+    /// Encodes into any writer rather than a file.
+    ///
+    /// The header carries `% geometry`, which a transport that already states the sensor size
+    /// out of band does not want repeated in the payload: ROS 2's
+    /// `event_camera_msgs/msg/EventPacket` puts width and height in its own fields and expects
+    /// `events` to be the encoded words alone. Pass `header = false` for that case.
+    pub fn to_writer(writer: W, version: EvtVersion, header: bool) -> Self {
+        Self {
+            writer,
+            version,
+            header_written: !header,
+            n_events: 0,
+            last_t: None,
+            state: EncoderState::default(),
+        }
+    }
+
+    /// The writer back, with everything appended so far in it.
+    pub fn into_inner(mut self) -> Result<W, IoError> {
+        self.writer.flush().map_err(IoError::Io)?;
+        Ok(self.writer)
     }
 
     fn word16(&mut self, kind: u16, payload: u16) -> Result<(), IoError> {
@@ -784,7 +844,7 @@ impl RawEventSink {
     }
 }
 
-impl super::EventSink for RawEventSink {
+impl<W: Write + Send> super::EventSink for RawEventSink<W> {
     fn append(&mut self, stream: &EventStream) -> Result<(), IoError> {
         if stream.is_empty() {
             return Ok(());

--- a/crates/eventcv-core/src/lib.rs
+++ b/crates/eventcv-core/src/lib.rs
@@ -48,6 +48,9 @@ pub mod mask;
 #[cfg(feature = "onnx")]
 pub mod model;
 pub mod net;
+#[cfg(feature = "ros2")]
+pub mod ros2;
+
 pub mod representation;
 pub mod simulate;
 pub mod track;

--- a/crates/eventcv-core/src/ros2.rs
+++ b/crates/eventcv-core/src/ros2.rs
@@ -303,6 +303,7 @@ impl Ros2Context {
             encoding: EvtVersion::Evt3,
             clock_offset_ns: 0,
             frame_id: "event_camera".to_owned(),
+            bytes: 0,
         })
     }
 
@@ -323,6 +324,7 @@ impl Ros2Context {
             _node: node,
             received: 0,
             last_seq: None,
+            last_time_base_ns: 0,
             dropped: 0,
         })
     }
@@ -376,6 +378,7 @@ pub struct EventPublisher {
     encoding: EvtVersion,
     clock_offset_ns: i64,
     frame_id: String,
+    bytes: usize,
 }
 
 impl EventPublisher {
@@ -409,6 +412,7 @@ impl EventPublisher {
             self.clock_offset_ns,
             &self.frame_id,
         )?;
+        self.bytes += packet.events.len();
         self.runtime
             .block_on(self.publisher.async_publish(&packet))
             .map_err(|e| Ros2Error::Transport(e.to_string()))?;
@@ -418,6 +422,15 @@ impl EventPublisher {
     /// How many packets have gone out.
     pub fn published(&self) -> u64 {
         self.seq
+    }
+
+    /// Bytes of encoded events put on the wire, not counting the rest of each message.
+    ///
+    /// Worth having outside a benchmark: it is what sizing a radio link comes down to, and the
+    /// answer depends on the recording — EVT3's vector words pay off on dense rows and cost on
+    /// sparse ones, so a number from someone else's data is not yours.
+    pub fn bytes_published(&self) -> usize {
+        self.bytes
     }
 }
 
@@ -437,6 +450,7 @@ pub struct EventSubscriber {
     _node: hiroz::node::ZNode,
     received: u64,
     last_seq: Option<u64>,
+    last_time_base_ns: u64,
     dropped: u64,
 }
 
@@ -463,6 +477,7 @@ impl EventSubscriber {
             self.dropped += packet.seq.saturating_sub(previous + 1);
         }
         self.last_seq = Some(packet.seq);
+        self.last_time_base_ns = packet.time_base;
         Ok(Some(packet))
     }
 
@@ -477,6 +492,15 @@ impl EventSubscriber {
     /// How many packets have arrived.
     pub fn received(&self) -> u64 {
         self.received
+    }
+
+    /// The ROS time on the most recent packet, in nanoseconds; zero before the first one.
+    ///
+    /// Kept because it is the only thing a decoded [`EventStream`] does not carry: the stream has
+    /// the sensor's clock, and this is where that clock sat in ROS time. Comparing it with the
+    /// clock now is how a consumer knows how old the events in its hands are.
+    pub fn last_time_base_ns(&self) -> u64 {
+        self.last_time_base_ns
     }
 
     /// How many packets the sequence numbers say went missing on the way. Reported rather than

--- a/crates/eventcv-core/src/ros2.rs
+++ b/crates/eventcv-core/src/ros2.rs
@@ -1,0 +1,1177 @@
+//! ROS 2 publish and subscribe, with no ROS 2 linked in.
+//!
+//! Every other way of speaking ROS 2 from Rust — `rclrs`, `r2r` — links the ROS C libraries,
+//! which means a ROS installation at build time, a second build system, and a package that
+//! cannot ship in a wheel. This module goes over [`hiroz`], a Zenoh-native ROS 2 stack in pure
+//! Rust, so the integration is a cargo feature rather than a separate distribution: `pip install
+//! eventcv` and you have a node.
+//!
+//! The trade is stated plainly: Zenoh on the wire means interoperating with ROS 2 deployments
+//! running `rmw_zenoh_cpp`. A deployment on the default DDS needs `zenoh-bridge-ros2dds` in
+//! between. That is a real constraint, not a detail.
+//!
+//! # What was checked, and one thing that does not work
+//!
+//! Against ROS 2 Rolling with `rmw_zenoh_cpp` 0.12.0: a topic published from here appears in
+//! `ros2 topic list` as `event_camera_msgs/msg/EventPacket`, `ros2 topic echo` deserialises it
+//! against the real `.msg`, and the RIHS01 type hash derived from the struct below matches the
+//! one ROS computes from the `.msg` — byte for byte, which is why no shared IDL is needed. A
+//! recording replayed to a topic and recorded back comes out event-identical.
+//!
+//! The gap is in one direction. `rmw_zenoh_cpp` 0.12.0 publishes any message carrying a `uint8[]`
+//! field through its new *buffer endpoints* path — its liveliness token gains a `backends:cpu`
+//! segment — and a subscriber that does not advertise a compatible backend receives nothing at
+//! all. `hiroz` 0.2.0 does not advertise one, so a C++ node publishing `EventPacket` (or
+//! `sensor_msgs/msg/Image`, or anything else with a byte array) is not received here, while a
+//! `String` is, and everything published from here is received there. Until `hiroz` speaks that
+//! part of the protocol, subscribing to a C++ event-camera driver on that `rmw_zenoh_cpp` version
+//! needs `zenoh-bridge-ros2dds` in front of it; publishing needs nothing.
+//!
+//! # Encoding
+//!
+//! [`EventPacket`] is `event_camera_msgs/msg/EventPacket`, the message the ROS 2 event-camera
+//! stack uses. Its `encoding` field takes `"evt3"`, which is a format this library already reads
+//! and writes, so a packet carries the sensor's own words rather than one message field per
+//! event: [`RawEventSink`](crate::io::RawEventSink) encodes and
+//! [`decode_words`](crate::io::decode_words) decodes, and no separate wire format exists to keep
+//! in step.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use hiroz::{context::ZContextBuilder, Builder, MessageTypeInfo};
+use hiroz_msgs::builtin_interfaces::Time;
+use hiroz_msgs::sensor_msgs::Image;
+use hiroz_msgs::std_msgs::Header;
+use hiroz_msgs::std_msgs::{Float32MultiArray, MultiArrayDimension, MultiArrayLayout};
+use serde::{Deserialize, Serialize};
+
+use crate::io::{decode_words, EvtVersion, IoError, RawEventSink};
+use crate::representation::{EventFrame, EventFrameData};
+use crate::{EventStream, EventStreamBuilder};
+
+/// EVT2 and EVT3 words carry microseconds, and so does everything this module encodes. A stream
+/// on another tick is rescaled on the way in rather than silently mis-timed.
+const MICROSECOND_SCALE_MS: f64 = 0.001;
+
+/// ROS time is nanoseconds; `EventPacket.time_base` is a ROS time.
+const NS_PER_US: i64 = 1_000;
+
+/// Rescales `stream` to microsecond ticks, which is what the EVT encoders write.
+fn in_microseconds(stream: &EventStream) -> std::borrow::Cow<'_, EventStream> {
+    let scale = stream.timestamp_scale_ms();
+    if (scale - MICROSECOND_SCALE_MS).abs() < f64::EPSILON {
+        return std::borrow::Cow::Borrowed(stream);
+    }
+    let factor = scale / MICROSECOND_SCALE_MS;
+    let (width, height) = stream.sensor_size();
+    let mut builder =
+        EventStreamBuilder::with_capacity(width, height, MICROSECOND_SCALE_MS, stream.len());
+    let (xs, ys, ts, ps) = (stream.xs(), stream.ys(), stream.ts(), stream.ps());
+    for i in 0..stream.len() {
+        builder.push(xs[i], ys[i], (ts[i] as f64 * factor).round() as i64, ps[i]);
+    }
+    std::borrow::Cow::Owned(builder.build())
+}
+
+/// What went wrong talking to ROS 2.
+#[derive(Debug)]
+pub enum Ros2Error {
+    /// The Zenoh session, node or endpoint could not be created.
+    Session(String),
+    /// A message could not be published or received.
+    Transport(String),
+    /// The payload did not decode: a truncated packet, or an `encoding` this build cannot read.
+    Payload(String),
+    /// Encoding or decoding events failed.
+    Io(IoError),
+}
+
+impl std::fmt::Display for Ros2Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Session(m) => write!(f, "ROS 2 session: {m}"),
+            Self::Transport(m) => write!(f, "ROS 2 transport: {m}"),
+            Self::Payload(m) => write!(f, "ROS 2 payload: {m}"),
+            Self::Io(e) => write!(f, "{e}"),
+        }
+    }
+}
+impl std::error::Error for Ros2Error {}
+impl From<IoError> for Ros2Error {
+    fn from(e: IoError) -> Self {
+        Self::Io(e)
+    }
+}
+
+type Result<T> = std::result::Result<T, Ros2Error>;
+
+// ---------------------------------------------------------------------------- messages ----
+
+/// `event_camera_msgs/msg/EventPacket`, field for field and in order.
+///
+/// CDR is positional, so the order below is the wire format and must match
+/// `msg_ros2/EventPacket.msg` in `ros-event-camera/event_camera_msgs` exactly. It is checked
+/// against a real ROS 2 node rather than against itself — see the interop test.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, MessageTypeInfo)]
+#[ros_msg(type_name = "event_camera_msgs/msg/EventPacket")]
+pub struct EventPacket {
+    pub header: Header,
+    pub height: u32,
+    pub width: u32,
+    /// Sequence number, for spotting a dropped packet.
+    pub seq: u64,
+    /// Event time is `time_base` plus the decoded per-event time.
+    pub time_base: u64,
+    /// `"evt3"`, `"evt2"`, `"libcaer"`, `"mono"`, ... — this build reads the first two.
+    pub encoding: String,
+    pub is_bigendian: bool,
+    /// The encoded words. Not one field per event.
+    pub events: Vec<u8>,
+}
+
+impl hiroz::msg::ZMessage for EventPacket {
+    type Serdes = hiroz::msg::SerdeCdrSerdes<EventPacket>;
+}
+
+impl EventPacket {
+    /// Encodes a window of events into a packet.
+    ///
+    /// `time_base` is subtracted from every timestamp before encoding, which is what keeps the
+    /// per-event field narrow; the receiver adds it back.
+    pub fn encode(stream: &EventStream, seq: u64, encoding: EvtVersion) -> Result<Self> {
+        Self::encode_with(stream, seq, encoding, 0, "event_camera")
+    }
+
+    /// As [`encode`](Self::encode), with `clock_offset_ns` added to the sensor clock and a
+    /// `frame_id` on the header.
+    ///
+    /// The offset is what puts a recording's sensor time on the wall clock: a replay node sets it
+    /// once at start, a live camera leaves it at zero.
+    pub fn encode_with(
+        stream: &EventStream,
+        seq: u64,
+        encoding: EvtVersion,
+        clock_offset_ns: i64,
+        frame_id: &str,
+    ) -> Result<Self> {
+        let stream = in_microseconds(stream);
+        let (width, height) = stream.sensor_size();
+        // The message defines `event ros time = time_base + decoded event_time`, and a ROS time is
+        // nanoseconds; the words carry microseconds. So the base goes out in nanoseconds and the
+        // decoded remainder is scaled on the way back, which is also what `event_camera_codecs`
+        // does — a consumer that never heard of this library gets the right times.
+        let first_us = stream.ts().first().copied().unwrap_or(0);
+        let time_base_ns = (first_us * NS_PER_US)
+            .saturating_add(clock_offset_ns)
+            .max(0) as u64;
+        let shifted = stream.time_shift(-first_us);
+        let mut sink = RawEventSink::to_writer(Vec::new(), encoding, false);
+        {
+            use crate::io::EventSink;
+            sink.append(&shifted)?;
+        }
+        Ok(Self {
+            header: Header {
+                stamp: stamp_from_nanos(time_base_ns),
+                frame_id: frame_id.to_owned(),
+            },
+            height: height as u32,
+            width: width as u32,
+            seq,
+            time_base: time_base_ns,
+            encoding: match encoding {
+                EvtVersion::Evt2 => "evt2".to_owned(),
+                EvtVersion::Evt3 => "evt3".to_owned(),
+            },
+            is_bigendian: cfg!(target_endian = "big"),
+            events: sink.into_inner()?,
+        })
+    }
+
+    /// Decodes a packet back into a stream, with `time_base` added back on.
+    pub fn decode(&self) -> Result<EventStream> {
+        let version = match self.encoding.as_str() {
+            "evt3" => EvtVersion::Evt3,
+            "evt2" => EvtVersion::Evt2,
+            other => {
+                return Err(Ros2Error::Payload(format!(
+                    "this build decodes the \"evt2\" and \"evt3\" encodings; the packet says \
+                     \"{other}\". The ROS 2 event-camera stack also defines libcaer, \
+                     libcaer_cmp, mono and trigger."
+                )))
+            }
+        };
+        let stream = decode_words(
+            &self.events,
+            version,
+            self.width as usize,
+            self.height as usize,
+        )?;
+        Ok(stream.time_shift(self.time_base as i64 / NS_PER_US))
+    }
+
+    /// The packet's ROS time, in nanoseconds.
+    pub fn time_base_ns(&self) -> u64 {
+        self.time_base
+    }
+}
+
+/// Splits nanoseconds into the `sec`/`nanosec` pair a ROS header carries.
+fn stamp_from_nanos(ns: u64) -> Time {
+    Time {
+        sec: (ns / 1_000_000_000) as i32,
+        nanosec: (ns % 1_000_000_000) as u32,
+    }
+}
+
+// ----------------------------------------------------------------------------- context ----
+
+/// A ROS 2 context: one Zenoh session, one tokio runtime, shared by every node built from it.
+///
+/// The runtime lives here rather than in the caller because everything else in this library is
+/// synchronous, and a Python caller has no runtime to lend.
+pub struct Ros2Context {
+    ctx: hiroz::context::ZContext,
+    runtime: Arc<tokio::runtime::Runtime>,
+}
+
+impl Ros2Context {
+    /// Connects to a local `rmw_zenohd` router, which is what a ROS 2 system running
+    /// `rmw_zenoh_cpp` provides.
+    pub fn new() -> Result<Self> {
+        Self::with_endpoint(None)
+    }
+
+    /// The Zenoh session mode this integration uses unless told otherwise.
+    ///
+    /// `rmw_zenoh_cpp` runs every ROS 2 node as a Zenoh *client* of the local router, and a node
+    /// that joins the same deployment as a *peer* is not reliably routed to: it publishes into the
+    /// graph fine, but a subscription declared from peer mode did not receive from router-side
+    /// publishers in testing. Matching what the C++ side does is both the working configuration
+    /// and the least surprising one.
+    pub const DEFAULT_MODE: &'static str = "client";
+
+    /// As [`new`](Self::new), against a named router endpoint (`tcp/host:7447`).
+    pub fn with_endpoint(endpoint: Option<&str>) -> Result<Self> {
+        Self::with_endpoint_and_mode(endpoint, None)
+    }
+
+    /// As [`with_endpoint`](Self::with_endpoint), in an explicit Zenoh session mode
+    /// (`"client"`, `"peer"`, `"router"`).
+    pub fn with_endpoint_and_mode(endpoint: Option<&str>, mode: Option<&str>) -> Result<Self> {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| Ros2Error::Session(e.to_string()))?;
+        let ctx = {
+            let _guard = runtime.enter();
+            let builder = match endpoint {
+                Some(e) => ZContextBuilder::default()
+                    .with_router_endpoint(e)
+                    .map_err(|e| Ros2Error::Session(e.to_string()))?,
+                None => ZContextBuilder::default().connect_to_local_zenohd(),
+            };
+            let builder = builder.with_mode(mode.unwrap_or(Self::DEFAULT_MODE));
+            builder
+                .build()
+                .map_err(|e| Ros2Error::Session(e.to_string()))?
+        };
+        Ok(Self {
+            ctx,
+            runtime: Arc::new(runtime),
+        })
+    }
+
+    /// A publisher of [`EventPacket`] on `topic`, from a node called `node_name`.
+    pub fn event_publisher(&self, node_name: &str, topic: &str) -> Result<EventPublisher> {
+        let _guard = self.runtime.enter();
+        let node = self
+            .ctx
+            .create_node(node_name)
+            .build()
+            .map_err(|e| Ros2Error::Session(e.to_string()))?;
+        let publisher = node
+            .create_pub::<EventPacket>(topic)
+            .build()
+            .map_err(|e| Ros2Error::Session(e.to_string()))?;
+        Ok(EventPublisher {
+            publisher,
+            runtime: Arc::clone(&self.runtime),
+            _node: node,
+            seq: 0,
+            encoding: EvtVersion::Evt3,
+            clock_offset_ns: 0,
+            frame_id: "event_camera".to_owned(),
+        })
+    }
+
+    /// A subscriber to [`EventPacket`] on `topic`.
+    pub fn event_subscriber(&self, node_name: &str, topic: &str) -> Result<EventSubscriber> {
+        let _guard = self.runtime.enter();
+        let node = self
+            .ctx
+            .create_node(node_name)
+            .build()
+            .map_err(|e| Ros2Error::Session(e.to_string()))?;
+        let subscriber = node
+            .create_sub::<EventPacket>(topic)
+            .build()
+            .map_err(|e| Ros2Error::Session(e.to_string()))?;
+        Ok(EventSubscriber {
+            subscriber,
+            _node: node,
+            received: 0,
+            last_seq: None,
+            dropped: 0,
+        })
+    }
+
+    /// A publisher of `sensor_msgs/msg/Image` on `topic`, for sending a representation on to the
+    /// rest of a ROS 2 system — rviz, a recorder, a classifier that wants pixels.
+    pub fn image_publisher(&self, node_name: &str, topic: &str) -> Result<ImagePublisher> {
+        let _guard = self.runtime.enter();
+        let node = self
+            .ctx
+            .create_node(node_name)
+            .build()
+            .map_err(|e| Ros2Error::Session(e.to_string()))?;
+        let publisher = node
+            .create_pub::<Image>(topic)
+            .build()
+            .map_err(|e| Ros2Error::Session(e.to_string()))?;
+        Ok(ImagePublisher {
+            publisher,
+            _node: node,
+            frame_id: "event_camera".to_owned(),
+        })
+    }
+
+    /// A publisher of `std_msgs/msg/Float32MultiArray` on `topic` — where a model's output goes.
+    pub fn tensor_publisher(&self, node_name: &str, topic: &str) -> Result<TensorPublisher> {
+        let _guard = self.runtime.enter();
+        let node = self
+            .ctx
+            .create_node(node_name)
+            .build()
+            .map_err(|e| Ros2Error::Session(e.to_string()))?;
+        let publisher = node
+            .create_pub::<Float32MultiArray>(topic)
+            .build()
+            .map_err(|e| Ros2Error::Session(e.to_string()))?;
+        Ok(TensorPublisher {
+            publisher,
+            _node: node,
+            labels: Vec::new(),
+        })
+    }
+}
+
+/// Publishes windows of events as `event_camera_msgs/msg/EventPacket`.
+pub struct EventPublisher {
+    publisher: hiroz::pubsub::ZPub<EventPacket, hiroz::msg::SerdeCdrSerdes<EventPacket>>,
+    runtime: Arc<tokio::runtime::Runtime>,
+    _node: hiroz::node::ZNode,
+    seq: u64,
+    encoding: EvtVersion,
+    clock_offset_ns: i64,
+    frame_id: String,
+}
+
+impl EventPublisher {
+    /// Encode as EVT2 instead of the EVT3 default.
+    pub fn with_encoding(mut self, encoding: EvtVersion) -> Self {
+        self.encoding = encoding;
+        self
+    }
+
+    /// Adds `ns` to every packet's `time_base`, which is how a replay of a recording that starts
+    /// at sensor time zero is stamped with a plausible wall clock.
+    pub fn with_clock_offset(mut self, ns: i64) -> Self {
+        self.clock_offset_ns = ns;
+        self
+    }
+
+    /// The `frame_id` on every header. Defaults to `event_camera`.
+    pub fn with_frame_id(mut self, frame_id: &str) -> Self {
+        self.frame_id = frame_id.to_owned();
+        self
+    }
+
+    /// Encodes and publishes one window. The sequence number advances per call, so a subscriber
+    /// can see a gap.
+    pub fn publish(&mut self, stream: &EventStream) -> Result<u64> {
+        self.seq += 1;
+        let packet = EventPacket::encode_with(
+            stream,
+            self.seq,
+            self.encoding,
+            self.clock_offset_ns,
+            &self.frame_id,
+        )?;
+        self.runtime
+            .block_on(self.publisher.async_publish(&packet))
+            .map_err(|e| Ros2Error::Transport(e.to_string()))?;
+        Ok(self.seq)
+    }
+
+    /// How many packets have gone out.
+    pub fn published(&self) -> u64 {
+        self.seq
+    }
+}
+
+// -------------------------------------------------------------------------- subscriber ----
+
+/// Receives `event_camera_msgs/msg/EventPacket` and decodes it back into a stream.
+///
+/// Nothing here is event-camera-specific beyond the decode: what comes out is an
+/// [`EventStream`], so every representation, filter and model in this library applies to a live
+/// topic exactly as it does to a file. That is the whole point of the integration.
+/// Named through the builder's associated output rather than spelled out, because the queue's
+/// element type is a Zenoh type and this crate does not depend on Zenoh directly — hiroz does.
+type EventSub = <hiroz::pubsub::ZSubBuilder<EventPacket, hiroz::msg::SerdeCdrSerdes<EventPacket>> as Builder>::Output;
+
+pub struct EventSubscriber {
+    subscriber: EventSub,
+    _node: hiroz::node::ZNode,
+    received: u64,
+    last_seq: Option<u64>,
+    dropped: u64,
+}
+
+impl EventSubscriber {
+    /// The next packet, or `Ok(None)` if none arrived inside `timeout`.
+    ///
+    /// A timeout is not an error: a subscriber on a quiet topic is doing its job. Only a
+    /// malformed payload is.
+    pub fn recv_packet(&mut self, timeout: Duration) -> Result<Option<EventPacket>> {
+        let packet = match self.subscriber.recv_timeout(timeout) {
+            Ok(packet) => packet,
+            // hiroz reports a timeout as an error; everything else about the queue is fatal, but
+            // there is no typed variant to match on, so the message is all there is to go by.
+            Err(e) => {
+                let text = e.to_string();
+                if is_timeout(&text) {
+                    return Ok(None);
+                }
+                return Err(Ros2Error::Transport(text));
+            }
+        };
+        self.received += 1;
+        if let Some(previous) = self.last_seq {
+            self.dropped += packet.seq.saturating_sub(previous + 1);
+        }
+        self.last_seq = Some(packet.seq);
+        Ok(Some(packet))
+    }
+
+    /// The next packet, already decoded.
+    pub fn recv(&mut self, timeout: Duration) -> Result<Option<EventStream>> {
+        match self.recv_packet(timeout)? {
+            Some(packet) => Ok(Some(packet.decode()?)),
+            None => Ok(None),
+        }
+    }
+
+    /// How many packets have arrived.
+    pub fn received(&self) -> u64 {
+        self.received
+    }
+
+    /// How many packets the sequence numbers say went missing on the way. Reported rather than
+    /// hidden: a representation built from a topic that quietly dropped a third of its packets is
+    /// not the representation the caller thinks it is.
+    pub fn dropped(&self) -> u64 {
+        self.dropped
+    }
+}
+
+fn is_timeout(message: &str) -> bool {
+    let text = message.to_ascii_lowercase();
+    text.contains("timeout") || text.contains("timed out")
+}
+
+// --------------------------------------------------------------------- image publisher ----
+
+/// Publishes an [`EventFrame`] as `sensor_msgs/msg/Image`.
+///
+/// The channel count picks the encoding — `mono8`, `mono16`, `32FC3` for a three-bin voxel grid —
+/// so a representation this library already computes shows up in rviz without a conversion node
+/// in between.
+pub struct ImagePublisher {
+    publisher: hiroz::pubsub::ZPub<Image, <Image as hiroz::msg::ZMessage>::Serdes>,
+    _node: hiroz::node::ZNode,
+    frame_id: String,
+}
+
+impl ImagePublisher {
+    /// The `frame_id` on every header. Defaults to `event_camera`.
+    pub fn with_frame_id(mut self, frame_id: &str) -> Self {
+        self.frame_id = frame_id.to_owned();
+        self
+    }
+
+    /// Publishes `frame`, stamped `stamp_ns`.
+    pub fn publish(&self, frame: &EventFrame, stamp_ns: u64) -> Result<()> {
+        let image = self.to_image(frame, stamp_ns)?;
+        self.publisher
+            .publish(&image)
+            .map_err(|e| Ros2Error::Transport(e.to_string()))
+    }
+
+    /// The `sensor_msgs/msg/Image` for `frame`, without publishing it.
+    pub fn to_image(&self, frame: &EventFrame, stamp_ns: u64) -> Result<Image> {
+        image_message(frame, stamp_ns, &self.frame_id)
+    }
+}
+
+/// The `sensor_msgs/msg/Image` for `frame`. Free-standing so it can be checked without a Zenoh
+/// session — the shaping is the part that can be wrong, and it should not need a router to test.
+pub fn image_message(frame: &EventFrame, stamp_ns: u64, frame_id: &str) -> Result<Image> {
+    let (channels, height, width) = frame.shape();
+    if channels == 0 || width == 0 || height == 0 {
+        return Err(Ros2Error::Payload("frame has a zero dimension".to_owned()));
+    }
+    let (encoding, sample_bytes, bytes) = encode_frame(frame.data(), channels, width, height)?;
+    Ok(Image {
+        header: Header {
+            stamp: stamp_from_nanos(stamp_ns),
+            frame_id: frame_id.to_owned(),
+        },
+        height: height as u32,
+        width: width as u32,
+        encoding,
+        is_bigendian: u8::from(cfg!(target_endian = "big")),
+        step: (width * channels * sample_bytes) as u32,
+        data: bytes.into(),
+    })
+}
+
+/// Interleaves a channel-major `[C, H, W]` buffer into the pixel-major order a ROS image wants.
+///
+/// Representations here are planar because that is what a model wants; `sensor_msgs/Image` is
+/// interleaved because that is what a display wants. One of the two has to give, and it is not
+/// the one with a published spec.
+fn interleave<T: Copy, const N: usize>(
+    values: &[T],
+    channels: usize,
+    pixels: usize,
+    to_bytes: impl Fn(T) -> [u8; N],
+) -> Vec<u8> {
+    if channels == 1 {
+        return values.iter().flat_map(|v| to_bytes(*v)).collect();
+    }
+    let mut out = Vec::with_capacity(pixels * channels * N);
+    for pixel in 0..pixels {
+        for channel in 0..channels {
+            out.extend_from_slice(&to_bytes(values[channel * pixels + pixel]));
+        }
+    }
+    out
+}
+
+/// Maps a frame's samples onto a ROS image encoding, its sample size, and interleaved bytes.
+///
+/// `u64` has no ROS encoding — an unnormalised event count is the common case — so it is narrowed
+/// to 16 bits with saturation rather than refused. A pixel that genuinely saw more than 65535
+/// events in one window saturates, which is the honest outcome for a display format.
+fn encode_frame(
+    data: &EventFrameData,
+    channels: usize,
+    width: usize,
+    height: usize,
+) -> Result<(String, usize, Vec<u8>)> {
+    if channels > 4 {
+        return Err(Ros2Error::Payload(format!(
+            "sensor_msgs/Image tops out at 4 channels; this frame has {channels}. Publish one \
+             topic per channel, or reduce the representation first."
+        )));
+    }
+    let pixels = width * height;
+    let expect = |len: usize| -> Result<()> {
+        if len == pixels * channels {
+            Ok(())
+        } else {
+            Err(Ros2Error::Payload(format!(
+                "frame says {channels}x{height}x{width} but carries {len} samples"
+            )))
+        }
+    };
+    Ok(match data {
+        EventFrameData::U8(values) => {
+            expect(values.len())?;
+            let name = if channels == 1 {
+                "mono8".to_owned()
+            } else {
+                format!("8UC{channels}")
+            };
+            (name, 1, interleave(values, channels, pixels, |v| [v]))
+        }
+        EventFrameData::U16(values) => {
+            expect(values.len())?;
+            let name = if channels == 1 {
+                "mono16".to_owned()
+            } else {
+                format!("16UC{channels}")
+            };
+            (
+                name,
+                2,
+                interleave(values, channels, pixels, u16::to_ne_bytes),
+            )
+        }
+        EventFrameData::U64(values) => {
+            expect(values.len())?;
+            let name = if channels == 1 {
+                "mono16".to_owned()
+            } else {
+                format!("16UC{channels}")
+            };
+            (
+                name,
+                2,
+                interleave(values, channels, pixels, |v: u64| {
+                    (v.min(u16::MAX as u64) as u16).to_ne_bytes()
+                }),
+            )
+        }
+        EventFrameData::F32(values) => {
+            expect(values.len())?;
+            (
+                format!("32FC{channels}"),
+                4,
+                interleave(values, channels, pixels, f32::to_ne_bytes),
+            )
+        }
+    })
+}
+
+// -------------------------------------------------------------------------- inference ----
+
+/// Publishes an arbitrary float tensor as `std_msgs/msg/Float32MultiArray`.
+///
+/// A model's output is a tensor of some shape the message cannot name, so the shape travels in the
+/// layout's dimension labels and the consumer reshapes. This is what `Float32MultiArray` is for,
+/// and it beats inventing a message that only this library speaks.
+pub struct TensorPublisher {
+    publisher:
+        hiroz::pubsub::ZPub<Float32MultiArray, <Float32MultiArray as hiroz::msg::ZMessage>::Serdes>,
+    _node: hiroz::node::ZNode,
+    labels: Vec<String>,
+}
+
+impl TensorPublisher {
+    /// Names the axes, which is how a consumer knows what it is looking at. Defaults to
+    /// `dim0`, `dim1`, …
+    pub fn with_labels<I, T>(mut self, labels: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<String>,
+    {
+        self.labels = labels.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Publishes `values` laid out as `shape`, row-major.
+    pub fn publish(&self, shape: &[usize], values: Vec<f32>) -> Result<()> {
+        self.publisher
+            .publish(&self.to_message(shape, values)?)
+            .map_err(|e| Ros2Error::Transport(e.to_string()))
+    }
+
+    /// The message for `values`, without publishing it.
+    pub fn to_message(&self, shape: &[usize], values: Vec<f32>) -> Result<Float32MultiArray> {
+        tensor_message(shape, values, &self.labels)
+    }
+}
+
+/// The `std_msgs/msg/Float32MultiArray` for `values` laid out as `shape`, row-major. Free-standing
+/// for the same reason [`image_message`] is.
+pub fn tensor_message(
+    shape: &[usize],
+    values: Vec<f32>,
+    labels: &[String],
+) -> Result<Float32MultiArray> {
+    {
+        let expected: usize = shape.iter().product();
+        if expected != values.len() {
+            return Err(Ros2Error::Payload(format!(
+                "shape {shape:?} wants {expected} values, got {}",
+                values.len()
+            )));
+        }
+        // ROS defines `stride` as the number of elements spanned by one step along that axis,
+        // counting the axis itself: the first is the whole tensor, the last is its own size.
+        let mut dim = Vec::with_capacity(shape.len());
+        for (axis, &size) in shape.iter().enumerate() {
+            let stride: usize = shape[axis..].iter().product();
+            dim.push(MultiArrayDimension {
+                label: labels
+                    .get(axis)
+                    .cloned()
+                    .unwrap_or_else(|| format!("dim{axis}")),
+                size: size as u32,
+                stride: stride as u32,
+            });
+        }
+        Ok(Float32MultiArray {
+            layout: MultiArrayLayout {
+                dim,
+                data_offset: 0,
+            },
+            data: values,
+        })
+    }
+}
+
+/// A representation as a model input: the shape, and the samples as `f32`.
+///
+/// Every representation this library computes is a dense `[C, H, W]` block in one of four sample
+/// types; a graph wants `f32` and usually a leading batch axis. Doing the widening here means the
+/// inference node does not care which representation it was handed.
+pub fn frame_as_input(frame: &EventFrame) -> (Vec<usize>, Vec<f32>) {
+    let (channels, height, width) = frame.shape();
+    let values = match frame.data() {
+        EventFrameData::U8(v) => v.iter().map(|&x| x as f32).collect(),
+        EventFrameData::U16(v) => v.iter().map(|&x| x as f32).collect(),
+        EventFrameData::U64(v) => v.iter().map(|&x| x as f32).collect(),
+        EventFrameData::F32(v) => v.clone(),
+    };
+    (vec![1, channels, height, width], values)
+}
+
+/// Subscribes to a topic, builds a representation, runs a graph, publishes the result.
+///
+/// The preprocessing step is a closure rather than a representation name, because the core has no
+/// name-to-representation table and should not grow one for this: the caller already chose a
+/// representation, and the bindings already parse names. [`frame_as_input`] is the bridge.
+#[cfg(feature = "onnx")]
+pub struct InferenceNode {
+    subscriber: EventSubscriber,
+    model: crate::model::Model,
+    publisher: TensorPublisher,
+    #[allow(clippy::type_complexity)]
+    preprocess: Box<dyn FnMut(&EventStream) -> Result<(Vec<usize>, Vec<f32>)> + Send>,
+    inferred: u64,
+}
+
+#[cfg(feature = "onnx")]
+impl InferenceNode {
+    pub fn new(
+        subscriber: EventSubscriber,
+        model: crate::model::Model,
+        publisher: TensorPublisher,
+        preprocess: impl FnMut(&EventStream) -> Result<(Vec<usize>, Vec<f32>)> + Send + 'static,
+    ) -> Self {
+        Self {
+            subscriber,
+            model,
+            publisher,
+            preprocess: Box::new(preprocess),
+            inferred: 0,
+        }
+    }
+
+    /// The common case: a voxel grid in, the graph's first output out.
+    pub fn with_voxel(
+        subscriber: EventSubscriber,
+        model: crate::model::Model,
+        publisher: TensorPublisher,
+        bins: usize,
+        window_ms: f64,
+    ) -> Self {
+        use crate::representation::{Representation, VoxelGrid};
+        let voxel = VoxelGrid::new(bins, window_ms);
+        Self::new(subscriber, model, publisher, move |stream| {
+            let frame = voxel
+                .generate(stream)
+                .map_err(|e| Ros2Error::Payload(e.to_string()))?;
+            Ok(frame_as_input(&frame))
+        })
+    }
+
+    /// One packet in, one inference out. `Ok(None)` when nothing arrived inside `timeout`.
+    ///
+    /// Returns the published output's shape, so a caller can log what the graph actually produced
+    /// rather than what it was supposed to.
+    pub fn step(&mut self, timeout: Duration) -> Result<Option<Vec<usize>>> {
+        let Some(stream) = self.subscriber.recv(timeout)? else {
+            return Ok(None);
+        };
+        let (shape, values) = (self.preprocess)(&stream)?;
+        let input = ndarray::ArrayD::from_shape_vec(ndarray::IxDyn(&shape), values)
+            .map_err(|e| Ros2Error::Payload(e.to_string()))?;
+        let outputs = self
+            .model
+            .run(input)
+            .map_err(|e| Ros2Error::Payload(e.to_string()))?;
+        let first = outputs
+            .into_iter()
+            .next()
+            .ok_or_else(|| Ros2Error::Payload("the graph produced no output".to_owned()))?;
+        let shape = first.shape().to_vec();
+        let (values, _) = first.into_raw_vec_and_offset();
+        self.publisher.publish(&shape, values)?;
+        self.inferred += 1;
+        Ok(Some(shape))
+    }
+
+    /// Runs until the topic goes quiet for `idle`, or `max_packets` have been through.
+    pub fn run(&mut self, idle: Duration, max_packets: Option<u64>) -> Result<u64> {
+        while !max_packets.is_some_and(|cap| self.inferred >= cap) {
+            if self.step(idle)?.is_none() {
+                break;
+            }
+        }
+        Ok(self.inferred)
+    }
+
+    /// How many packets have been through the graph.
+    pub fn inferred(&self) -> u64 {
+        self.inferred
+    }
+
+    /// What the loaded graph expects and produces — for a caller that wants to check the model
+    /// matches the representation before starting.
+    pub fn ports(&self) -> (&[crate::model::Port], &[crate::model::Port]) {
+        (self.model.inputs(), self.model.outputs())
+    }
+}
+
+// ------------------------------------------------------------------- replay and record ----
+
+/// What a replay did.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReplayReport {
+    /// Packets published — one per non-empty window.
+    pub packets: u64,
+    /// Events published.
+    pub events: usize,
+    /// Windows that held no events and so were not published.
+    pub empty_windows: u64,
+}
+
+/// Publishes a recording onto a topic, one `window_ms` slice at a time.
+///
+/// This is the same windowing the rest of the library uses, so a topic replayed from a file and a
+/// file read directly give the same slices — which is what makes the round-trip test below worth
+/// anything.
+///
+/// `wall_clock` stamps the packets against the current time instead of the sensor's own clock, and
+/// paces the publishing to match: what you want when something downstream is timing itself against
+/// the header. Without it the replay runs as fast as the topic will take it, which is what you
+/// want when something downstream is being tested.
+pub fn replay_file(
+    publisher: &mut EventPublisher,
+    path: impl AsRef<std::path::Path>,
+    window_ms: f64,
+    wall_clock: bool,
+) -> Result<ReplayReport> {
+    // `<= 0.0` rather than `!(> 0.0)` so a NaN window is caught by the `is_finite` half rather
+    // than by the negation, which clippy rightly says is hard to read.
+    if !window_ms.is_finite() || window_ms <= 0.0 {
+        return Err(Ros2Error::Payload(
+            "the replay window must be a positive number of milliseconds".to_owned(),
+        ));
+    }
+    let reader = crate::io::open(path, crate::io::LoadOptions::default())?;
+    let (t0, t1) = reader.time_span();
+    let step = (window_ms * 1_000.0).round() as i64;
+    let started = std::time::Instant::now();
+    if wall_clock {
+        let now_ns = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|e| Ros2Error::Session(e.to_string()))?
+            .as_nanos() as i64;
+        publisher.clock_offset_ns = now_ns - t0.saturating_mul(NS_PER_US);
+    }
+    let mut report = ReplayReport {
+        packets: 0,
+        events: 0,
+        empty_windows: 0,
+    };
+    let mut t = t0;
+    while t <= t1 {
+        let slice = reader.slice_time(t, t + step)?;
+        if slice.is_empty() {
+            report.empty_windows += 1;
+        } else {
+            report.events += slice.len();
+            report.packets += 1;
+            publisher.publish(&slice)?;
+        }
+        if wall_clock {
+            // Pace against the recording's own clock rather than sleeping a fixed step, so a slow
+            // window does not push every window after it late.
+            let due = Duration::from_micros((t + step - t0).max(0) as u64);
+            if let Some(wait) = due.checked_sub(started.elapsed()) {
+                std::thread::sleep(wait);
+            }
+        }
+        t += step;
+    }
+    Ok(report)
+}
+
+/// What a recording run did.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RecordReport {
+    pub packets: u64,
+    pub events: usize,
+    /// Packets the sequence numbers say never arrived.
+    pub dropped: u64,
+}
+
+/// Writes everything arriving on a topic into a file, in any format this library writes.
+///
+/// Stops after `idle` with nothing on the topic, or after `max_packets` — whichever comes first.
+/// `None` for the cap means "until the topic goes quiet", which is how you record a replay without
+/// knowing in advance how long it is.
+pub fn record_topic(
+    subscriber: &mut EventSubscriber,
+    path: impl AsRef<std::path::Path>,
+    idle: Duration,
+    max_packets: Option<u64>,
+) -> Result<RecordReport> {
+    let mut sink = crate::io::open_sink(path, &crate::io::SaveOptions::default())?;
+    let mut report = RecordReport {
+        packets: 0,
+        events: 0,
+        dropped: 0,
+    };
+    loop {
+        if max_packets.is_some_and(|cap| report.packets >= cap) {
+            break;
+        }
+        match subscriber.recv(idle)? {
+            Some(stream) => {
+                report.events += stream.len();
+                report.packets += 1;
+                sink.append(&stream)?;
+            }
+            None => break,
+        }
+    }
+    report.dropped = subscriber.dropped();
+    sink.finish()?;
+    Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::representation::Representation;
+    use crate::EventStreamBuilder;
+
+    fn stream() -> EventStream {
+        let mut b = EventStreamBuilder::new(1280, 720, 0.001);
+        for i in 0..500i64 {
+            b.push(
+                (i % 1280) as u16,
+                (i % 720) as u16,
+                1_000_000 + i * 37,
+                i % 2 == 0,
+            );
+        }
+        b.build()
+    }
+
+    #[test]
+    fn a_packet_round_trips_through_evt3() {
+        let original = stream();
+        let packet = EventPacket::encode(&original, 1, EvtVersion::Evt3).unwrap();
+        assert_eq!(packet.encoding, "evt3");
+        assert_eq!(packet.width, 1280);
+        assert_eq!(packet.height, 720);
+        // The payload is encoded words, not one field per event.
+        assert!(packet.events.len() < original.len() * 8);
+        let back = packet.decode().unwrap();
+        assert_eq!(back.len(), original.len(), "event count changed");
+        assert_eq!(back.xs(), original.xs(), "x changed");
+        assert_eq!(back.ys(), original.ys(), "y changed");
+        assert_eq!(back.ts(), original.ts(), "timestamps changed");
+        assert_eq!(back.ps(), original.ps(), "polarity changed");
+    }
+
+    #[test]
+    fn evt2_round_trips_too() {
+        let original = stream();
+        let packet = EventPacket::encode(&original, 7, EvtVersion::Evt2).unwrap();
+        assert_eq!(packet.encoding, "evt2");
+        assert_eq!(packet.seq, 7);
+        let back = packet.decode().unwrap();
+        assert_eq!(back.ts(), original.ts());
+        assert_eq!(back.xs(), original.xs());
+    }
+
+    #[test]
+    fn an_unknown_encoding_names_the_ones_that_work() {
+        let mut packet = EventPacket::encode(&stream(), 1, EvtVersion::Evt3).unwrap();
+        packet.encoding = "libcaer".to_owned();
+        let message = packet.decode().unwrap_err().to_string();
+        assert!(message.contains("libcaer"), "{message}");
+        assert!(message.contains("evt3"), "{message}");
+    }
+
+    #[test]
+    fn the_time_base_is_a_ros_time_in_nanoseconds() {
+        // The message says "event ros time = time_base + decoded event_time", and a decoder that
+        // never heard of this library reads the words as microseconds. So the base has to be
+        // nanoseconds, or every consumer downstream is out by a factor of a thousand.
+        let original = stream();
+        let first_us = original.ts()[0];
+        let packet = EventPacket::encode(&original, 1, EvtVersion::Evt3).unwrap();
+        assert_eq!(packet.time_base_ns(), (first_us * 1_000) as u64);
+        assert_eq!(packet.header.stamp.sec, (first_us / 1_000_000) as i32);
+        assert_eq!(packet.decode().unwrap().ts()[0], first_us);
+    }
+
+    #[test]
+    fn a_clock_offset_moves_the_base_and_nothing_else() {
+        let original = stream();
+        let hour_ns = 3_600 * 1_000_000_000i64;
+        let packet =
+            EventPacket::encode_with(&original, 1, EvtVersion::Evt3, hour_ns, "cam0").unwrap();
+        assert_eq!(packet.header.frame_id, "cam0");
+        assert_eq!(
+            packet.time_base_ns(),
+            (original.ts()[0] * 1_000 + hour_ns) as u64
+        );
+        let back = packet.decode().unwrap();
+        // Every event moved by the same hour; the intervals are untouched.
+        let shift = back.ts()[0] - original.ts()[0];
+        assert_eq!(shift, hour_ns / 1_000);
+        for (a, b) in back.ts().iter().zip(original.ts()) {
+            assert_eq!(a - b, shift);
+        }
+    }
+
+    #[test]
+    fn a_stream_on_another_tick_is_rescaled_not_mis_timed() {
+        // A stream in milliseconds, not microseconds: the encoder writes EVT words, which are
+        // microseconds by definition, so the conversion has to happen somewhere.
+        let mut b = EventStreamBuilder::new(64, 64, 1.0);
+        for i in 0..50i64 {
+            b.push(i as u16, i as u16, 100 + i, i % 2 == 0);
+        }
+        let millis = b.build();
+        let packet = EventPacket::encode(&millis, 1, EvtVersion::Evt3).unwrap();
+        // 100 ms is 100_000 us is 100_000_000 ns.
+        assert_eq!(packet.time_base_ns(), 100_000_000);
+        let back = packet.decode().unwrap();
+        assert_eq!(back.len(), millis.len());
+        assert_eq!(back.ts()[0], 100_000);
+        assert_eq!(back.ts()[49], 149_000);
+    }
+
+    #[test]
+    fn a_count_frame_becomes_a_mono16_image() {
+        let frame = crate::representation::EventCount::new(false)
+            .generate(&stream())
+            .unwrap();
+        let (encoding, sample, bytes) = encode_frame(frame.data(), 1, 1280, 720).unwrap();
+        assert_eq!(encoding, "mono16");
+        assert_eq!(sample, 2);
+        assert_eq!(bytes.len(), 1280 * 720 * 2);
+    }
+
+    #[test]
+    fn a_voxel_grid_is_interleaved_into_32fc3() {
+        let frame = crate::representation::VoxelGrid::new(3, 30.0)
+            .generate(&stream())
+            .unwrap();
+        let (channels, height, width) = frame.shape();
+        assert_eq!(channels, 3);
+        let (encoding, sample, bytes) =
+            encode_frame(frame.data(), channels, width, height).unwrap();
+        assert_eq!(encoding, "32FC3");
+        assert_eq!(sample, 4);
+        assert_eq!(bytes.len(), width * height * 3 * 4);
+
+        // Pixel-major, not plane-major: pixel 0's three channels come first.
+        let planar = match frame.data() {
+            EventFrameData::F32(v) => v.clone(),
+            other => panic!("voxel grid is f32, got {other:?}"),
+        };
+        let pixels = width * height;
+        for channel in 0..3 {
+            let at = channel * 4;
+            let read = f32::from_ne_bytes(bytes[at..at + 4].try_into().unwrap());
+            assert_eq!(read, planar[channel * pixels]);
+        }
+    }
+
+    #[test]
+    fn an_image_message_carries_the_layout_ros_expects() {
+        let frame = crate::representation::VoxelGrid::new(3, 30.0)
+            .generate(&stream())
+            .unwrap();
+        let image = image_message(&frame, 1_500_000_042, "cam0").unwrap();
+        assert_eq!(image.encoding, "32FC3");
+        assert_eq!((image.width, image.height), (1280, 720));
+        // step is one row of interleaved pixels, in bytes.
+        assert_eq!(image.step, 1280 * 3 * 4);
+        assert_eq!(image.header.frame_id, "cam0");
+        assert_eq!(image.header.stamp.sec, 1);
+        assert_eq!(image.header.stamp.nanosec, 500_000_042);
+    }
+
+    #[test]
+    fn a_tensor_message_strides_the_ros_way() {
+        // ROS strides count the axis itself: dim[i].stride is the product of shape[i..].
+        let message = tensor_message(&[2, 3, 4], vec![0.0; 24], &[]).unwrap();
+        let dims = &message.layout.dim;
+        assert_eq!(dims.len(), 3);
+        assert_eq!(
+            dims.iter().map(|d| d.size).collect::<Vec<_>>(),
+            vec![2, 3, 4]
+        );
+        assert_eq!(
+            dims.iter().map(|d| d.stride).collect::<Vec<_>>(),
+            vec![24, 12, 4]
+        );
+        assert_eq!(
+            dims.iter().map(|d| d.label.as_str()).collect::<Vec<_>>(),
+            vec!["dim0", "dim1", "dim2"]
+        );
+        assert_eq!(message.data.len(), 24);
+    }
+
+    #[test]
+    fn a_tensor_message_checks_the_shape_against_the_data() {
+        let message = tensor_message(&[2, 3], vec![0.0; 5], &[])
+            .unwrap_err()
+            .to_string();
+        assert!(message.contains('6'), "{message}");
+        assert!(message.contains('5'), "{message}");
+    }
+
+    #[test]
+    fn a_frame_becomes_a_batched_float_input() {
+        let frame = crate::representation::EventCount::new(false)
+            .generate(&stream())
+            .unwrap();
+        let (shape, values) = frame_as_input(&frame);
+        assert_eq!(shape, vec![1, 1, 720, 1280]);
+        assert_eq!(values.len(), 720 * 1280);
+        // The counts widened rather than being reinterpreted.
+        let counted: f32 = values.iter().sum();
+        assert_eq!(counted as usize, stream().len());
+    }
+
+    #[test]
+    fn too_many_channels_says_so() {
+        let data = EventFrameData::F32(vec![0.0; 5 * 4]);
+        let message = encode_frame(&data, 5, 2, 2).unwrap_err().to_string();
+        assert!(message.contains("4 channels"), "{message}");
+        assert!(message.contains('5'), "{message}");
+    }
+
+    #[test]
+    fn an_empty_window_is_an_empty_packet() {
+        let empty = EventStreamBuilder::new(640, 480, 0.001).build();
+        let packet = EventPacket::encode(&empty, 1, EvtVersion::Evt3).unwrap();
+        assert_eq!(packet.decode().unwrap().len(), 0);
+    }
+}

--- a/crates/eventcv-core/tests/ros2_roundtrip.rs
+++ b/crates/eventcv-core/tests/ros2_roundtrip.rs
@@ -1,0 +1,109 @@
+//! The ROS 2 round-trip, against a live Zenoh router.
+//!
+//! Ignored by default because it needs one running — `ros2 run rmw_zenoh_cpp rmw_zenohd`, or any
+//! `zenohd` on the default port. Run it with:
+//!
+//! ```text
+//! cargo test -p eventcv-core --features ros2 --test ros2_roundtrip -- --ignored --nocapture
+//! ```
+//!
+//! What it pins down is the thing the unit tests cannot: that a stream published as
+//! `event_camera_msgs/msg/EventPacket` and received back through a real router is the same stream,
+//! event for event, and that the sequence numbers account for every packet.
+
+#![cfg(feature = "ros2")]
+
+use std::time::Duration;
+
+use eventcv_core::ros2::{record_topic, Ros2Context};
+use eventcv_core::{EventStream, EventStreamBuilder};
+
+fn synthetic() -> EventStream {
+    let mut builder = EventStreamBuilder::new(640, 480, 0.001);
+    for i in 0..120_000i64 {
+        builder.push(
+            (i % 640) as u16,
+            ((i / 640) % 480) as u16,
+            1_000_000 + i * 3,
+            i % 3 == 0,
+        );
+    }
+    builder.build()
+}
+
+#[test]
+#[ignore = "needs a running Zenoh router (rmw_zenohd)"]
+fn a_stream_survives_a_round_trip_through_ros2() {
+    let dir = std::env::temp_dir().join(format!("eventcv_ros2_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("temp dir");
+    let source = dir.join("source.raw");
+    let recorded = dir.join("recorded.raw");
+    eventcv_core::io::save_stream(&source, &synthetic(), &Default::default())
+        .expect("write source");
+
+    let topic = format!("/eventcv_test/{}", std::process::id());
+    let recorder_topic = topic.clone();
+    let recorded_path = recorded.clone();
+
+    // The subscriber has to exist before the publisher starts, or the first packets go out to
+    // nobody — a property of publish/subscribe, not a flake to paper over with a retry.
+    let recorder = std::thread::spawn(move || {
+        let context = Ros2Context::new().expect("context");
+        let mut subscriber = context
+            .event_subscriber("eventcv_test_sub", &recorder_topic)
+            .expect("subscriber");
+        record_topic(
+            &mut subscriber,
+            &recorded_path,
+            Duration::from_secs(10),
+            None,
+        )
+        .expect("record")
+    });
+
+    std::thread::sleep(Duration::from_secs(3));
+    let context = Ros2Context::new().expect("context");
+    let mut publisher = context
+        .event_publisher("eventcv_test_pub", &topic)
+        .expect("publisher");
+    std::thread::sleep(Duration::from_secs(2));
+
+    // Published window by window rather than through `replay_file`, for two reasons: no clock
+    // offset, so the timestamps that come back should be the ones that went out; and a small pace,
+    // because an unpaced publisher outruns the default KeepLast(10) queue by two orders of
+    // magnitude and this test is about fidelity, not back-pressure.
+    let reader = eventcv_core::io::open(&source, Default::default()).expect("open source");
+    let (t0, t1) = reader.time_span();
+    let step = 33_000i64;
+    let (mut packets, mut events) = (0u64, 0usize);
+    let mut t = t0;
+    while t <= t1 {
+        let slice = reader.slice_time(t, t + step).expect("slice");
+        if !slice.is_empty() {
+            publisher.publish(&slice).expect("publish");
+            packets += 1;
+            events += slice.len();
+            std::thread::sleep(Duration::from_millis(2));
+        }
+        t += step;
+    }
+
+    let report = recorder.join().expect("recorder thread");
+    assert_eq!(report.packets, packets, "packet count");
+    assert_eq!(report.events, events, "event count");
+    assert_eq!(report.dropped, 0, "packets dropped");
+
+    let before = eventcv_core::io::load(&source, Default::default()).expect("read source");
+    let after = eventcv_core::io::load(&recorded, Default::default()).expect("read recorded");
+    assert_eq!(
+        after.len(),
+        before.len(),
+        "event count after the round trip"
+    );
+    assert_eq!(after.xs(), before.xs(), "x");
+    assert_eq!(after.ys(), before.ys(), "y");
+    assert_eq!(after.ts(), before.ts(), "timestamps");
+    assert_eq!(after.ps(), before.ps(), "polarity");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/eventcv-py/Cargo.toml
+++ b/crates/eventcv-py/Cargo.toml
@@ -40,3 +40,6 @@ onnx = ["eventcv-core/onnx"]
 # Build the GPU compute kernels into the extension (forwards to eventcv-core). The viewer's wgpu is
 # the same dependency, so this adds shaders rather than a second graphics stack.
 gpu = ["eventcv-core/gpu"]
+# Build the ROS 2 nodes into the extension (forwards to eventcv-core, which goes over hiroz — a
+# pure-Rust Zenoh-native ROS 2 stack, so this needs no ROS installation at build time).
+ros2 = ["eventcv-core/ros2"]

--- a/crates/eventcv-py/src/capture.rs
+++ b/crates/eventcv-py/src/capture.rs
@@ -64,6 +64,10 @@ struct Shared {
     recorded: AtomicUsize,
     /// Windows that arrived first-after-overflow — i.e. the driver dropped events before them.
     overflows: AtomicUsize,
+    /// Events discarded on purpose in [`Backpressure::Latest`] mode, decoded but never built into a
+    /// window. Counted exactly, because a drop policy nobody can quantify is a bias on everything
+    /// downstream of it.
+    skimmed: AtomicUsize,
 }
 
 #[derive(Default)]
@@ -85,11 +89,7 @@ pub(crate) struct Pump {
 
 impl Pump {
     /// Spawns the pump thread and starts decoding immediately.
-    pub(crate) fn start(
-        capture: Capture,
-        recorder: Option<Recorder>,
-        mode: Backpressure,
-    ) -> Self {
+    pub(crate) fn start(capture: Capture, recorder: Option<Recorder>, mode: Backpressure) -> Self {
         let shared = Arc::new(Shared {
             queue: Mutex::new(Queue::default()),
             signal: Condvar::new(),
@@ -98,6 +98,7 @@ impl Pump {
             bias: Mutex::new(capture.bias_state()),
             recorded: AtomicUsize::new(recorder.as_ref().map_or(0, Recorder::n_events)),
             overflows: AtomicUsize::new(0),
+            skimmed: AtomicUsize::new(0),
         });
         let worker = Arc::clone(&shared);
         // The camera and the open recording are owned *outside* the unwind boundary so a panic in
@@ -162,6 +163,10 @@ impl Pump {
         self.shared.queue.lock().unwrap().skipped
     }
 
+    pub(crate) fn n_skimmed_events(&self) -> usize {
+        self.shared.skimmed.load(Ordering::Relaxed)
+    }
+
     /// Stops the thread and hands back the camera (and the open recording, if any). A panic inside
     /// the decode loop is caught and republished as an error, so both still come back; `None` means
     /// the thread died in a way even that could not recover from.
@@ -205,9 +210,34 @@ fn run(
     mode: Backpressure,
 ) {
     'pump: while !shared.stop.load(Ordering::Acquire) {
+        // In `Latest` mode the consumer has said it only wants the newest window, so anything
+        // queued behind the freshest buffer is going to be discarded by `offer` anyway. Skimming
+        // those buffers — decoding their words for the stream state, discarding their events —
+        // reaches the same answer without building the columns first, and it keeps the driver's
+        // ring drained. That second part is the one that matters: a full ring back-pressures into
+        // the sensor, where events are lost with nothing to count them, so the cheapest drop is
+        // also the only one that stays visible.
+        // Not while a recording is open. `record=` promises the file gets every window even in
+        // `Latest` mode --- that is the whole point of archiving on this thread rather than the
+        // consumer's --- and a skimmed buffer's events are gone before the recorder could see
+        // them. Someone who asked for a complete recording asked for complete decoding with it.
+        if matches!(mode, Backpressure::Latest) && recorder.is_none() {
+            while capture.backlog() > 1 {
+                match capture.skim_next(Duration::ZERO) {
+                    Ok(Some(events)) => {
+                        shared.skimmed.fetch_add(events, Ordering::Relaxed);
+                    }
+                    Ok(None) => break,
+                    Err(message) => {
+                        fail(shared, message);
+                        break 'pump;
+                    }
+                }
+            }
+        }
         // One buffer per pass, its windows handed on before the next: `offer` is what throttles
-        // decoding when the consumer stalls, so the backlog waits in the driver's ring rather than
-        // ballooning into decoded columns here.
+        // decoding when the consumer stalls, so in `Buffer` mode the backlog waits in the driver's
+        // ring rather than ballooning into decoded columns here.
         let decoded = match capture.decode_next(DECODE_TIMEOUT) {
             Ok(decoded) => decoded,
             Err(message) => {

--- a/crates/eventcv-py/src/lib.rs
+++ b/crates/eventcv-py/src/lib.rs
@@ -7010,6 +7010,16 @@ impl PyRos2Publisher {
     fn published(&self) -> u64 {
         self.inner.lock().expect("publisher mutex").published()
     }
+
+    /// Bytes of encoded events put on the wire, not counting the rest of each message — what
+    /// sizing a link comes down to.
+    #[getter]
+    fn bytes_published(&self) -> usize {
+        self.inner
+            .lock()
+            .expect("publisher mutex")
+            .bytes_published()
+    }
 }
 
 /// Receives `event_camera_msgs/msg/EventPacket` and hands back streams.
@@ -7060,6 +7070,16 @@ impl PyRos2Subscriber {
     #[getter]
     fn received(&self) -> u64 {
         self.inner.lock().expect("subscriber mutex").received()
+    }
+
+    /// The ROS time the most recent packet carried, in nanoseconds; 0 before the first one.
+    /// Comparing it with the clock now is how a consumer knows how old its events are.
+    #[getter]
+    fn last_time_base_ns(&self) -> u64 {
+        self.inner
+            .lock()
+            .expect("subscriber mutex")
+            .last_time_base_ns()
     }
 
     /// How many packets the sequence numbers say went missing. Reported rather than hidden.

--- a/crates/eventcv-py/src/lib.rs
+++ b/crates/eventcv-py/src/lib.rs
@@ -5578,6 +5578,20 @@ impl PyEventCamera {
     /// Times the driver's ring overflowed and dropped events before a window — the loss `n_skipped`
     /// can't prevent, because it happens upstream of eventcv. Non-zero means the camera outran the
     /// decoder or the recording; lower the event rate, or record uncompressed.
+    /// Events discarded on purpose by `latest=True`, counted exactly.
+    ///
+    /// `n_skipped` counts whole windows the consumer never saw; this counts the events inside the
+    /// ones dropped before a window was ever built. Together they are the whole of what this
+    /// library throws away deliberately — `n_overflows` is the part the driver threw away, which
+    /// only it can see.
+    #[getter]
+    fn n_skimmed_events(&self) -> PyResult<usize> {
+        match &self.state {
+            CameraState::Pumping(pump) => Ok(pump.n_skimmed_events()),
+            _ => Ok(0),
+        }
+    }
+
     #[getter]
     fn n_overflows(&self) -> usize {
         self.overflows + self.pump().map_or(0, capture::Pump::n_overflows)

--- a/crates/eventcv-py/src/lib.rs
+++ b/crates/eventcv-py/src/lib.rs
@@ -6846,7 +6846,252 @@ fn _rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
         m.add_function(wrap_pyfunction!(stream, m)?)?;
         m.add_function(wrap_pyfunction!(record, m)?)?;
     }
+    #[cfg(feature = "ros2")]
+    {
+        m.add_class::<PyRos2Context>()?;
+        m.add_class::<PyRos2Publisher>()?;
+        m.add_class::<PyRos2Subscriber>()?;
+        m.add_class::<PyRos2ImagePublisher>()?;
+    }
     Ok(())
+}
+
+// ------------------------------------------------------------------------------- ROS 2 ----
+
+#[cfg(feature = "ros2")]
+use pyo3::exceptions::PyConnectionError;
+#[cfg(feature = "ros2")]
+use std::path::PathBuf as Ros2Path;
+#[cfg(feature = "ros2")]
+use std::time::Duration as Ros2Duration;
+
+#[cfg(feature = "ros2")]
+fn map_ros2_error(error: eventcv_core::ros2::Ros2Error) -> PyErr {
+    use eventcv_core::ros2::Ros2Error;
+    match error {
+        Ros2Error::Io(error) => map_io_error(error),
+        Ros2Error::Payload(message) => PyValueError::new_err(message),
+        Ros2Error::Session(message) | Ros2Error::Transport(message) => {
+            PyConnectionError::new_err(message)
+        }
+    }
+}
+
+/// A ROS 2 context: one Zenoh session shared by every node made from it.
+///
+/// Nothing here links a ROS 2 library, so a node is `pip install eventcv` and a Python file — no
+/// ROS installation, no colcon workspace, no second build system. The wire is Zenoh, so the ROS 2
+/// side must be running `rmw_zenoh_cpp` (or a `zenoh-bridge-ros2dds` in front of a DDS one).
+#[cfg(feature = "ros2")]
+#[pyclass(name = "Ros2Context")]
+struct PyRos2Context {
+    inner: eventcv_core::ros2::Ros2Context,
+}
+
+#[cfg(feature = "ros2")]
+#[pymethods]
+impl PyRos2Context {
+    /// `router` names the Zenoh router (`"tcp/host:7447"`); the default is the local `rmw_zenohd`
+    /// that an `rmw_zenoh_cpp` deployment already runs. `mode` is the Zenoh session mode and
+    /// defaults to `"client"`, which is what the C++ ROS 2 nodes use.
+    #[new]
+    #[pyo3(signature = (*, router=None, mode=None))]
+    fn new(router: Option<&str>, mode: Option<&str>) -> PyResult<Self> {
+        eventcv_core::ros2::Ros2Context::with_endpoint_and_mode(router, mode)
+            .map(|inner| Self { inner })
+            .map_err(map_ros2_error)
+    }
+
+    /// A publisher of `event_camera_msgs/msg/EventPacket` on `topic`.
+    #[pyo3(signature = (topic="/event_camera/events", *, node="eventcv_publisher", encoding="evt3", frame_id="event_camera"))]
+    fn publisher(
+        &self,
+        topic: &str,
+        node: &str,
+        encoding: &str,
+        frame_id: &str,
+    ) -> PyResult<PyRos2Publisher> {
+        let version = parse_evt_version(encoding)?;
+        let inner = self
+            .inner
+            .event_publisher(node, topic)
+            .map_err(map_ros2_error)?
+            .with_encoding(version)
+            .with_frame_id(frame_id);
+        Ok(PyRos2Publisher {
+            inner: Mutex::new(inner),
+        })
+    }
+
+    /// A subscriber to `event_camera_msgs/msg/EventPacket` on `topic`.
+    #[pyo3(signature = (topic="/event_camera/events", *, node="eventcv_subscriber"))]
+    fn subscriber(&self, topic: &str, node: &str) -> PyResult<PyRos2Subscriber> {
+        self.inner
+            .event_subscriber(node, topic)
+            .map(|inner| PyRos2Subscriber {
+                inner: Mutex::new(inner),
+            })
+            .map_err(map_ros2_error)
+    }
+
+    /// A publisher of `sensor_msgs/msg/Image` on `topic` — where a representation goes.
+    #[pyo3(signature = (topic="/event_camera/image", *, node="eventcv_image_publisher", frame_id="event_camera"))]
+    fn image_publisher(
+        &self,
+        topic: &str,
+        node: &str,
+        frame_id: &str,
+    ) -> PyResult<PyRos2ImagePublisher> {
+        self.inner
+            .image_publisher(node, topic)
+            .map(|inner| PyRos2ImagePublisher {
+                inner: inner.with_frame_id(frame_id),
+            })
+            .map_err(map_ros2_error)
+    }
+}
+
+#[cfg(feature = "ros2")]
+fn parse_evt_version(name: &str) -> PyResult<eventcv_core::io::EvtVersion> {
+    match name {
+        "evt3" => Ok(eventcv_core::io::EvtVersion::Evt3),
+        "evt2" => Ok(eventcv_core::io::EvtVersion::Evt2),
+        other => Err(PyValueError::new_err(format!(
+            "encoding must be \"evt3\" or \"evt2\", got {other:?}"
+        ))),
+    }
+}
+
+/// Publishes windows of events as `event_camera_msgs/msg/EventPacket`.
+///
+/// Behind a `Mutex` because publishing advances the sequence number and a `#[pyclass]` must be
+/// `Sync`; it is a single-writer object in practice.
+#[cfg(feature = "ros2")]
+#[pyclass(name = "Ros2Publisher")]
+struct PyRos2Publisher {
+    inner: Mutex<eventcv_core::ros2::EventPublisher>,
+}
+
+#[cfg(feature = "ros2")]
+#[pymethods]
+impl PyRos2Publisher {
+    /// Publishes one window; returns its sequence number.
+    fn publish(&self, py: Python<'_>, stream: PyRef<'_, PyEventStream>) -> PyResult<u64> {
+        let inner = &stream.inner;
+        py.detach(|| self.inner.lock().expect("publisher mutex").publish(inner))
+            .map_err(map_ros2_error)
+    }
+
+    /// Replays a recording onto the topic, one `window_ms` slice at a time.
+    ///
+    /// `wall_clock=True` stamps against the current time and paces to match, which is what you
+    /// want when something downstream times itself against the header.
+    #[pyo3(signature = (path, *, window_ms=33.0, wall_clock=false))]
+    fn replay(
+        &self,
+        py: Python<'_>,
+        path: Ros2Path,
+        window_ms: f64,
+        wall_clock: bool,
+    ) -> PyResult<(u64, usize)> {
+        py.detach(|| {
+            eventcv_core::ros2::replay_file(
+                &mut self.inner.lock().expect("publisher mutex"),
+                &path,
+                window_ms,
+                wall_clock,
+            )
+        })
+        .map(|report| (report.packets, report.events))
+        .map_err(map_ros2_error)
+    }
+
+    #[getter]
+    fn published(&self) -> u64 {
+        self.inner.lock().expect("publisher mutex").published()
+    }
+}
+
+/// Receives `event_camera_msgs/msg/EventPacket` and hands back streams.
+#[cfg(feature = "ros2")]
+#[pyclass(name = "Ros2Subscriber")]
+struct PyRos2Subscriber {
+    inner: Mutex<eventcv_core::ros2::EventSubscriber>,
+}
+
+#[cfg(feature = "ros2")]
+#[pymethods]
+impl PyRos2Subscriber {
+    /// The next packet as an `EventStream`, or `None` if none arrived inside `timeout_ms`.
+    ///
+    /// A timeout is `None` rather than an exception: a subscriber on a quiet topic is doing its
+    /// job, and `while (s := sub.recv()) is not None` reads the way it should.
+    #[pyo3(signature = (*, timeout_ms=1000.0))]
+    fn recv(&self, py: Python<'_>, timeout_ms: f64) -> PyResult<Option<PyEventStream>> {
+        let timeout = Ros2Duration::from_secs_f64((timeout_ms / 1000.0).max(0.0));
+        py.detach(|| self.inner.lock().expect("subscriber mutex").recv(timeout))
+            .map(|stream| stream.map(|inner| PyEventStream { inner, repr: None }))
+            .map_err(map_ros2_error)
+    }
+
+    /// Records the topic to `path` until it goes quiet for `idle_ms`, or `max_packets` arrive.
+    /// Returns `(packets, events, dropped)`.
+    #[pyo3(signature = (path, *, idle_ms=5000.0, max_packets=None))]
+    fn record(
+        &self,
+        py: Python<'_>,
+        path: Ros2Path,
+        idle_ms: f64,
+        max_packets: Option<u64>,
+    ) -> PyResult<(u64, usize, u64)> {
+        let idle = Ros2Duration::from_secs_f64((idle_ms / 1000.0).max(0.0));
+        py.detach(|| {
+            eventcv_core::ros2::record_topic(
+                &mut self.inner.lock().expect("subscriber mutex"),
+                &path,
+                idle,
+                max_packets,
+            )
+        })
+        .map(|report| (report.packets, report.events, report.dropped))
+        .map_err(map_ros2_error)
+    }
+
+    #[getter]
+    fn received(&self) -> u64 {
+        self.inner.lock().expect("subscriber mutex").received()
+    }
+
+    /// How many packets the sequence numbers say went missing. Reported rather than hidden.
+    #[getter]
+    fn dropped(&self) -> u64 {
+        self.inner.lock().expect("subscriber mutex").dropped()
+    }
+}
+
+/// Publishes an `EventFrame` as `sensor_msgs/msg/Image`, so a representation shows up in rviz.
+#[cfg(feature = "ros2")]
+#[pyclass(name = "Ros2ImagePublisher")]
+struct PyRos2ImagePublisher {
+    inner: eventcv_core::ros2::ImagePublisher,
+}
+
+#[cfg(feature = "ros2")]
+#[pymethods]
+impl PyRos2ImagePublisher {
+    /// `stamp_ns` is the ROS time to put on the header; pass a packet's `time_base` to keep the
+    /// image aligned with the events it came from.
+    #[pyo3(signature = (frame, *, stamp_ns=0))]
+    fn publish(
+        &self,
+        py: Python<'_>,
+        frame: PyRef<'_, PyEventFrame>,
+        stamp_ns: u64,
+    ) -> PyResult<()> {
+        let inner = &frame.inner;
+        py.detach(|| self.inner.publish(inner, stamp_ns))
+            .map_err(map_ros2_error)
+    }
 }
 
 #[cfg(test)]

--- a/crates/eventcv-py/src/viewer/gpu.rs
+++ b/crates/eventcv-py/src/viewer/gpu.rs
@@ -473,16 +473,17 @@ impl ApplicationHandler<UserEvent> for App {
                     self.last_cursor = None;
                 }
             }
-            WindowEvent::CursorMoved { position, .. } => {
-                if self.dragging && self.is_cloud {
-                    if let Some((last_x, last_y)) = self.last_cursor {
-                        self.yaw += (position.x - last_x) as f32 * 0.008;
-                        self.pitch =
-                            (self.pitch + (position.y - last_y) as f32 * 0.008).clamp(-1.45, 1.45);
-                        self.redraw();
-                    }
-                    self.last_cursor = Some((position.x, position.y));
+            // Guarded rather than tested inside the arm: the only arm that could otherwise
+            // catch a cursor move is the final `_ => {}`, so this is the same behaviour and
+            // clippy stops asking.
+            WindowEvent::CursorMoved { position, .. } if self.dragging && self.is_cloud => {
+                if let Some((last_x, last_y)) = self.last_cursor {
+                    self.yaw += (position.x - last_x) as f32 * 0.008;
+                    self.pitch =
+                        (self.pitch + (position.y - last_y) as f32 * 0.008).clamp(-1.45, 1.45);
+                    self.redraw();
                 }
+                self.last_cursor = Some((position.x, position.y));
             }
             WindowEvent::MouseWheel { delta, .. } if self.is_cloud => {
                 // Positive scroll (wheel up / two-finger up) zooms in. Multiplicative so each

--- a/python/eventcv/__main__.py
+++ b/python/eventcv/__main__.py
@@ -227,6 +227,67 @@ def _cmd_simulate(args: argparse.Namespace) -> int:
     return 0
 
 
+_NO_ROS2 = (
+    "eventcv was built without ROS 2 support. Install a build with the `ros2` feature. It needs "
+    "no ROS installation of its own — the wire is Zenoh — but the ROS 2 side must be running "
+    "rmw_zenoh_cpp, or have a zenoh-bridge-ros2dds in front of a DDS one."
+)
+
+
+def _ros2_context(args: argparse.Namespace):
+    from . import Ros2Context
+
+    if Ros2Context is None:
+        raise OSError(_NO_ROS2)
+    return Ros2Context(router=args.router or None, mode=args.mode or None)
+
+
+def _cmd_ros2_publish(args: argparse.Namespace) -> int:
+    """Replay a recording onto a ROS 2 topic."""
+    import time
+
+    context = _ros2_context(args)
+    publisher = context.publisher(args.topic, encoding=args.encoding, frame_id=args.frame_id)
+    # Discovery is not instantaneous, and packets published before anyone has matched are simply
+    # gone — a silent empty run is a worse default than a short wait.
+    time.sleep(args.settle)
+    packets, events = publisher.replay(
+        args.input, window_ms=args.window_ms, wall_clock=not args.as_fast_as_possible
+    )
+    if not args.quiet:
+        print(f"published {packets} packets, {events} events on {args.topic}")
+    return 0
+
+
+def _cmd_ros2_record(args: argparse.Namespace) -> int:
+    """Record a ROS 2 topic to a file."""
+    context = _ros2_context(args)
+    subscriber = context.subscriber(args.topic)
+    packets, events, dropped = subscriber.record(
+        args.output, idle_ms=args.idle * 1000.0, max_packets=args.max_packets
+    )
+    if not args.quiet:
+        note = f", {dropped} dropped" if dropped else ""
+        print(f"recorded {packets} packets, {events} events{note} -> {args.output}")
+    return 0
+
+
+def _cmd_ros2_represent(args: argparse.Namespace) -> int:
+    """Subscribe to a topic, build a representation, publish it as sensor_msgs/Image."""
+    context = _ros2_context(args)
+    subscriber = context.subscriber(args.topic)
+    images = context.image_publisher(args.image_topic)
+    made = 0
+    while (stream := subscriber.recv(timeout_ms=args.idle * 1000.0)) is not None:
+        images.publish(stream.view(args.repr, bins=args.bins) if args.repr == "voxel"
+                       else stream.view(args.repr))
+        made += 1
+    if not args.quiet:
+        note = f", {subscriber.dropped} dropped" if subscriber.dropped else ""
+        print(f"published {made} images on {args.image_topic}{note}")
+    return 0
+
+
 def _cmd_reconstruct(args: argparse.Namespace) -> int:
     """Run a reconstruction model over a recording to recover an intensity video."""
     from . import Model, open as open_reader, reconstruct
@@ -445,6 +506,63 @@ def build_parser() -> argparse.ArgumentParser:
     reconstruct.add_argument("-q", "--quiet", action="store_true",
                              help="suppress the summary line")
     reconstruct.set_defaults(func=_cmd_reconstruct)
+
+    def _add_ros2_options(sub: argparse.ArgumentParser) -> None:
+        sub.add_argument("--router", default="", metavar="ENDPOINT",
+                         help="Zenoh router (default: the local rmw_zenohd)")
+        sub.add_argument("--mode", default="", choices=["", "client", "peer", "router"],
+                         help="Zenoh session mode (default: client, as rmw_zenoh_cpp uses)")
+        sub.add_argument("-q", "--quiet", action="store_true",
+                         help="suppress the summary line")
+
+    ros2_publish = subparsers.add_parser(
+        "ros2-publish", help="replay a recording onto a ROS 2 topic"
+    )
+    ros2_publish.add_argument("input", help="source recording")
+    ros2_publish.add_argument("--topic", default="/event_camera/events",
+                              help="topic (default: /event_camera/events)")
+    ros2_publish.add_argument("--window-ms", type=float, default=33.0, metavar="MS",
+                              help="events per packet, in milliseconds (default: 33)")
+    ros2_publish.add_argument("--encoding", default="evt3", choices=["evt3", "evt2"],
+                              help="how the events are packed into the message (default: evt3)")
+    ros2_publish.add_argument("--frame-id", default="event_camera",
+                              help="frame_id on every header (default: event_camera)")
+    ros2_publish.add_argument("--settle", type=float, default=2.0, metavar="S",
+                              help="wait this long for discovery before publishing (default: 2)")
+    ros2_publish.add_argument("--as-fast-as-possible", action="store_true",
+                              help="do not pace to the recording's own clock")
+    _add_ros2_options(ros2_publish)
+    ros2_publish.set_defaults(func=_cmd_ros2_publish)
+
+    ros2_record = subparsers.add_parser(
+        "ros2-record", help="record a ROS 2 topic to a file"
+    )
+    ros2_record.add_argument("output", help="destination; the extension picks the format")
+    ros2_record.add_argument("--topic", default="/event_camera/events",
+                             help="topic (default: /event_camera/events)")
+    ros2_record.add_argument("--idle", type=float, default=5.0, metavar="S",
+                             help="stop after this long with nothing on the topic (default: 5)")
+    ros2_record.add_argument("--max-packets", type=int, default=None, metavar="N",
+                             help="stop after N packets")
+    _add_ros2_options(ros2_record)
+    ros2_record.set_defaults(func=_cmd_ros2_record)
+
+    ros2_represent = subparsers.add_parser(
+        "ros2-represent",
+        help="subscribe to a topic and republish a representation as sensor_msgs/Image",
+    )
+    ros2_represent.add_argument("--topic", default="/event_camera/events",
+                                help="topic to subscribe to (default: /event_camera/events)")
+    ros2_represent.add_argument("--image-topic", default="/event_camera/image",
+                                help="topic to publish on (default: /event_camera/image)")
+    ros2_represent.add_argument("--repr", default="voxel",
+                                help="representation to build (default: voxel)")
+    ros2_represent.add_argument("--bins", type=int, default=3,
+                                help="bins, for the voxel representation (default: 3)")
+    ros2_represent.add_argument("--idle", type=float, default=5.0, metavar="S",
+                                help="stop after this long with nothing on the topic (default: 5)")
+    _add_ros2_options(ros2_represent)
+    ros2_represent.set_defaults(func=_cmd_ros2_represent)
 
     return parser
 

--- a/python/eventcv/load.py
+++ b/python/eventcv/load.py
@@ -321,6 +321,14 @@ SimulationResult = _rust.SimulationResult
 # USB camera support (the published wheels do); keep imports resilient otherwise.
 EventCamera = getattr(_rust, "EventCamera", None)
 
+# The ROS 2 nodes are built when the extension includes the `ros2` feature. They need no ROS
+# installation — the wire is Zenoh, over hiroz — but the ROS 2 side must be running
+# `rmw_zenoh_cpp`, or have a `zenoh-bridge-ros2dds` in front of a DDS one.
+Ros2Context = getattr(_rust, "Ros2Context", None)
+Ros2Publisher = getattr(_rust, "Ros2Publisher", None)
+Ros2Subscriber = getattr(_rust, "Ros2Subscriber", None)
+Ros2ImagePublisher = getattr(_rust, "Ros2ImagePublisher", None)
+
 # Sentinel for "to the end of the recording" — i64::MAX on the Rust side.
 _MAX_US = (1 << 63) - 1
 
@@ -1347,6 +1355,10 @@ __all__ = [
     "FrameSink",
     "Model",
     "Polarity",
+    "Ros2Context",
+    "Ros2ImagePublisher",
+    "Ros2Publisher",
+    "Ros2Subscriber",
     "SimulationResult",
     "StatefulModel",
     "Tracker",

--- a/python/eventcv/load.py
+++ b/python/eventcv/load.py
@@ -545,10 +545,19 @@ def stream(
     falls behind — the thread buffers a few windows, then applies backpressure, and under *sustained*
     overload the driver's ring is what finally overflows (watch :attr:`EventCamera.n_overflows`).
     Pass ``latest=True`` to trade completeness for freshness instead: reads hand back the **newest**
-    decoded window and drop what it overtook, keeping latency at about one window no matter how slow
-    the loop is. :attr:`EventCamera.n_skipped` counts the windows passed over, and ``record=`` still
-    archives every one of them from the capture thread — so the loop sees live data while the file
-    keeps the full recording.
+    decoded window and drop what it overtook. Buffers queued behind the freshest one are *skimmed* —
+    decoded far enough to keep the sensor's stream state exact, then discarded without being built
+    into windows — which is both cheaper than building results nobody reads and, more importantly,
+    keeps the driver's ring drained. That matters because a full ring backs pressure up into the
+    sensor, where events are lost with nothing able to count them. Two counters say what went:
+    :attr:`EventCamera.n_skipped` counts whole windows passed over and
+    :attr:`EventCamera.n_skimmed_events` counts events discarded before a window was built. Both are
+    exact; :attr:`EventCamera.n_overflows` remains the part the driver dropped, which only it sees.
+
+    Skimming is off while ``record=`` is open, because the file is promised every window and a
+    skimmed buffer's events are gone before the recorder could archive them. With a recording
+    attached the loop still gets the newest window and the file still gets all of them, at the old
+    cost — asking for a complete recording is asking for complete decoding to go with it.
 
     The returned camera is a context manager and an iterator::
 


### PR DESCRIPTION
- **fix cargo clippy test**
- **Decode EVT3 and AEDAT 4 faster, without changing what they produce** (sitting on top of #29)
- **Add ROS 2 nodes over hiroz, behind --features ros2**
- **Let a ROS 2 node report its own wire cost**
- **Do not break a default-feature build with the ROS 2 examples**