### PR TITLE
bump to 1.0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1690,7 +1690,7 @@ dependencies = [
 
 [[package]]
 name = "eventcv-core"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "bytemuck",
  "criterion",
@@ -1722,7 +1722,7 @@ dependencies = [
 
 [[package]]
 name = "eventcv-py"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "bytemuck",
  "egui",

--- a/crates/eventcv-core/Cargo.toml
+++ b/crates/eventcv-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eventcv-core"
-version = "1.0.6"
+version = "1.0.7"
 edition = "2021"
 description = "Rust core of EventCV — OpenCV for event-based vision."
 license = "Apache-2.0"

--- a/crates/eventcv-py/Cargo.toml
+++ b/crates/eventcv-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eventcv-py"
-version = "1.0.6"
+version = "1.0.7"
 edition = "2021"
 
 [lib]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -11,7 +11,7 @@ are in play and you want to be sure which interpreter is answering.
 
 ```console
 $ eventcv --version
-eventcv 1.0.6 (hdf5, camera, onnx)
+eventcv 1.0.7 (hdf5, camera, onnx)
 Python 3.12.10 on macOS-14.8.3-arm64-arm-64bit
 ```
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ copyright = "2026, EventLAB"
 try:
     release = _pkg_version("eventcv")
 except PackageNotFoundError:  # docs building against an uninstalled tree
-    release = "1.0.6"
+    release = "1.0.7"
 version = release
 
 extensions = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "maturin"
 
 [project]
 name = "eventcv"
-version = "1.0.6"
+version = "1.0.7"
 description = "Open source event-based computer vision library."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/python/eventcv/__main__.py
+++ b/python/eventcv/__main__.py
@@ -35,7 +35,7 @@ def _onnx_runtime_line() -> str | None:
 
 
 def version_text() -> str:
-    """``eventcv 1.0.6 (hdf5, camera)`` plus the runtime and the interpreter it is installed under."""
+    """``eventcv 1.0.7 (hdf5, camera)`` plus the runtime and the interpreter it is installed under."""
     features = ", ".join(getattr(_rust, "__features__", ())) or "no optional features"
     lines = [
         f"eventcv {__version__} ({features})",


### PR DESCRIPTION
Bumps every version declaration to 1.0.7, matching the file set touched by the 1.0.6 bump:

- `pyproject.toml`
- `crates/eventcv-core/Cargo.toml`, `crates/eventcv-py/Cargo.toml` (+ `Cargo.lock`)
- `docs/conf.py`, `docs/cli.md`, `python/eventcv/__main__.py` (docstring / example output)

`tests/test_version.py` guards agreement between the compiled extension, pyproject and both crates.

Note: the publish workflow (`workflow.yml`) runs on a GitHub **release published** event, not on a tag push, so after merging, tag `v1.0.7` and publish a release to ship wheels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EF8JGLDBHCtDWQWdtjGYxM
